### PR TITLE
EMCB-94: Add Bitbucket server reader and merge 'deldrid/hotfix/remote-relative-includes'

### DIFF
--- a/README.md
+++ b/README.md
@@ -560,7 +560,7 @@ This directive can be used to include local files, external sources or [macros](
 
         <pre><b>@include</b> "bitbucket-server:~john/Promise/promise.class.nut@v3.0.1"</pre>
     <a id='include-bitbucket-note1'></a>
-    **Note 1**: This section describes [**Bitbucket Server**](https://www.atlassian.com/software/bitbucket/download) includes. You can't use this to include files from [Bitbucket.org](https://bitbucket.org/).
+    **Note 1**: This section describes [**Bitbucket Server**](https://www.atlassian.com/software/bitbucket/download) (version **5.3.0** or above supported) includes. You can't use this to include files from [Bitbucket.org](https://bitbucket.org/).
 
     **Note 2**: Currently, only one server can be specified/used to fetch all Bitbucket Server includes.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <img src=docs/logo.png?2 width=180 alt=Builder><br />
 
-### Current version: 2.8.1 ###
+### Current version: 2.9.0 ###
 
 ![Build Status](https://cse-ci.electricimp.com/app/rest/builds/buildType:(id:Builder_BuildAndTest)/statusIcon)
 
@@ -31,7 +31,7 @@
             - [Define A Macro](#define-a-macro)
             - [Use A Macro](#use-a-macro)
         - [@include](#include)
-            - [GitHub Authentication](#github-authentication)
+            - [Authentication](#authentication)
         - [@include once](#include-once)
         - [@while](#while)
         - [@repeat](#repeat)
@@ -42,7 +42,7 @@
 - [Advanced Builder Usage](#advanced-builder-usage)
     - [Reproducible Artifacts](#reproducible-artifacts)
         - [Builder Variables: Directives](#builder-variables-directives)
-        - [GitHub Files: Dependencies](#github-files-dependencies)
+        - [GitHub And Bitbucket Server Files: Dependencies](#github-and-bitbucket-server-files-dependencies)
     - [Including JavaScript Libraries](#including-javascript-libraries)
         - [Binding The Context Object Correctly](#binding-the-context-object-correctly)
     - [Managing Remote Includes](#managing-remote-includes)
@@ -62,7 +62,7 @@ There are a number of ways in which you can [install Builder](#builder-installat
 
 You can use Builder to pull the contents of separate code files into your main source code files. These additional files might contain library code that you make use of across a number of different products, or they might contain confidential data which you don’t want to keep inside source code files that are managed through a software version control system.
 
-You tell Builder which files to import, and where within your main source code they should be inserted, by using the [`@include`](#include) command. Builder is able to access additional files that are stored on your computer or held remotely on a local network file share, on an Internet site or hosted by GitHub.
+You tell Builder which files to import, and where within your main source code they should be inserted, by using the [`@include`](#include) command. Builder is able to access additional files that are stored on your computer or held remotely on a local network file share, on an Internet site or hosted by GitHub or [Bitbucket Server](https://www.atlassian.com/software/bitbucket/download).
 
 While Builder can be used to insert code this way, it can be used in far more sophisticated ways thanks to its integrated expression processor and programming logic. For example, if you need to generate multiple versions of your application firmware for versions of your product which make use of different imp modules, you can use Builder’s [conditional execution features](#if-elif-else), [variables](#variables) and [loops](#while) to pull your various code components together at build time and output files that are ready to be transferred to impCentral.
 
@@ -90,8 +90,8 @@ Now use Builder’s `pleasebuild` command to configure the newly installed utili
 ```sh
 pleasebuild [-l] [-D<variable> <value>]
     [--github-user <username> --github-token <token>]
-    [--lib <path_to_file>]
-    [--use-remote-relative-includes] [--suppress-duplicate-includes-warning]
+    [--bitbucket-server-addr <address>] [--bitbucket-server-user <username> --bitbucket-server-token <token>]
+    [--lib <path_to_file>] [--use-remote-relative-includes] [--suppress-duplicate-includes-warning]
     [--cache] [--clear-cache] [--cache-exclude-list <path_to_file>]
     [--save-dependencies [<path_to_file>]] [--use-dependencies [<path_to_file>]]
     [--save-directives [<path_to_file>]] [--use-directives [<path_to_file>]]
@@ -106,14 +106,17 @@ where `<input_file>` is the path to source file which should be preprocessed and
 | -D&lt;variable&gt; | | No | Yes | Defines a [variable](#variables). May be specified several times to define multiple variables |
 | --github-user | | No | Yes | A GitHub username. |
 | --github-token | | No | Yes | A GitHub [personal access token](https://github.com/settings/tokens) or password (not recommended). Should be specified if the `--github-user` option is specified. |
+| --bitbucket-server-addr | | No | Yes | A Bitbucket Server address. E.g., `https://bitbucket-srv.itd.example.com`. **Note**: this option is mandatory to handle [Bitbucket Server include@ statements](#include-bitbucket) |
+| --bitbucket-server-user | | No | Yes | A Bitbucket Server username. |
+| --bitbucket-server-token | | No | Yes | A Bitbucket Server [personal access token](https://confluence.atlassian.com/bitbucketserver/personal-access-tokens-939515499.html) or password (not recommended). Should be specified if the `--bitbucket-server-user` option is specified. |
 | --lib | --libs | No | Yes | Include the specified [JavaScript file(s) as a library](#including-javascript-libraries). May be specified several times to include multiple libraries. The provided value may specify a concrete file or a directory (all files from the directory will be included). The value may contain [wildcards](https://www.npmjs.com/package/glob) (all matched files will be included) |
 | --use-remote-relative-includes | | No | No | Interpret every [local include](#include) as relative to the location of the source file where it is mentioned. See ['Local Includes From Remote Files'](#local-includes-from-remote-files) |
 | --suppress-duplicate-includes-warning | --suppress-duplicate | No | No | Do not show a warning if a source file with the same content was included multiple times from different locations and this results in code duplication |
 | --cache | -c | No | No | Turn on caching for all files included from remote resources. This option is ignored if the `--save-dependencies` or `--use-dependencies` options are specified. See [‘Caching Remote Includes’](#caching-remote-includes) |
 | --clear-cache | | No | No | Clear the cache before Builder starts running. See [‘Caching Remote Includes’](#caching-remote-includes) |
 | --cache-exclude-list | | No | Yes | Set the path to the file that lists resources which should not be cached. See [‘Caching Remote Includes’](#caching-remote-includes) |
-| --save-dependencies | | No | No | Save references to the required GitHub files in the specified file. If a file name is not specified, the `dependencies.json` file in the local directory is used. See [‘Reproducible Artifacts’](#reproducible-artifacts) |
-| --use-dependencies | | No | No | Use the specified file to set which GitHub files are required. If a file name is not specified, the `dependencies.json` file in the local directory is used. See [‘Reproducible Artifacts’](#reproducible-artifacts).  |
+| --save-dependencies | | No | No | Save references to the required GitHub/Bitbucket files in the specified file. If a file name is not specified, the `dependencies.json` file in the local directory is used. See [‘Reproducible Artifacts’](#reproducible-artifacts) |
+| --use-dependencies | | No | No | Use the specified file to set which GitHub/Bitbucket files are required. If a file name is not specified, the `dependencies.json` file in the local directory is used. See [‘Reproducible Artifacts’](#reproducible-artifacts).  |
 | --save-directives | | No | No | Save Builder variable definitions in the specified file. If a file name is not specified, the `directives.json` file in the local directory is used. See [‘Reproducible Artifacts’](#reproducible-artifacts) |
 | --use-directives | | No | No | Use Builder variable definitions from the specified file. If a file name is not specified, the `directives.json` file in the local directory is used. See [‘Reproducible Artifacts’](#reproducible-artifacts) |
 
@@ -141,11 +144,16 @@ builder.machine.useCache = <true|false>;
 builder.machine.readers.github.username = "<USERNAME>";
 builder.machine.readers.github.token = "<PASSWORD_OR_ACCESS_TOKEN>";
 
+// Set Bitbucket Server address and credentials. See the "--bitbucket-server-*" CLI options.
+builder.machine.readers.bitbucketSrv.serverAddr = "<ADDRESS>";
+builder.machine.readers.bitbucketSrv.username = "<USERNAME>";
+builder.machine.readers.bitbucketSrv.token = "<PASSWORD_OR_ACCESS_TOKEN>";
+
 // Path to the file that lists the resources which should be excluded from caching.
 // See the "--cache-exclude-list" CLI option.
 builder.machine.excludeList = "<PATH_TO_FILE>";
 
-// Replace local include paths to github URLs if requested.
+// Replace local include paths to github/bitbucket URLs if requested.
 // See the "--use-remote-relative-includes" CLI option.
 builder.machine.remoteRelativeIncludes = <true|false>;
 
@@ -524,9 +532,37 @@ This directive can be used to include local files, external sources or [macros](
 
         <pre><b>@include</b> "github:electricimp/Promise/promise.class.nut@develop"</pre>
 
-    - Tag _v3.0.1_:
+    - Tag _v3.0.1_
 
         <pre><b>@include</b> "github:electricimp/Promise/promise.class.nut@v3.0.1"</pre>
+<a id='include-bitbucket'></a>
+- For [Bitbucket Server](#include-bitbucket-note1) file, where:
+
+    - `project` is the project name (needed to include source files from project repos).
+    - `user` is the user name (needed to include source files from personal repos). **Note:** user name must be prepended with `~`. E.g., your user name is John - then you should write `~john`.
+    - `repo` is the repository name.
+    - `ref` is the git reference (branch name or tag, defaults to _master_).
+
+    <pre>// Include a source file from a project repo
+  <b>@include</b> "bitbucket-server:<i>&lt;project&gt;</i>/<i>&lt;repo&gt;</i>/<i>&lt;path&gt;</i>[@<i>&lt;ref&gt;</i>]"
+  // Include a source file from a personal repo
+  <b>@include</b> "bitbucket-server:<i>~&lt;user&gt;</i>/<i>&lt;repo&gt;</i>/<i>&lt;path&gt;</i>[@<i>&lt;ref&gt;</i>]"</pre>
+
+    - Head of the default branch
+
+        <pre><b>@include</b> "bitbucket-server:Tools/Promise/promise.class.nut"</pre>
+
+    - Head of the _develop_ branch
+
+        <pre><b>@include</b> "bitbucket-server:Tools/Promise/promise.class.nut@develop"</pre>
+
+    - Tag _v3.0.1_ (personal repo)
+
+        <pre><b>@include</b> "bitbucket-server:~john/Promise/promise.class.nut@v3.0.1"</pre>
+    <a id='include-bitbucket-note1'></a>
+    **Note 1**: This section describes [**Bitbucket Server**](https://www.atlassian.com/software/bitbucket/download) includes. You can't use this to include files from [Bitbucket.org](https://bitbucket.org/).
+
+    **Note 2**: Currently, only one server can be specified/used to fetch all Bitbucket Server includes.
 
 The `@include` directive can be combined with the `__PATH__` [variable](#builder-variables) to build references to your files.
 
@@ -537,14 +573,26 @@ The `@include` directive can be combined with the `__PATH__` [variable](#builder
 @include __PATH__ + "/../shared/Constants.shared.nut"
 ```
 
-#### GitHub Authentication ####
+#### Authentication ####
+
+##### GitHub #####
 
 When using GitHub `@include` statements, authentication is optional. However, you should bear in mind that:
 
 - If you use authentication, the GitHub API provides much higher rate limits.
 - Authentication is required to access private repositories.
 
-Apart from a GitHub username, you need to provide either a [personal access token](https://github.com/settings/tokens) **or** a password (which is less secure and not recommended). If you are using Builder as a [library](#library-installation), GitHub credentials can be stored using your system's environment variables or in files that store Builder variables. When you are using Builder's [command line tool](#command-line-tool-installation), your GitHub credentials will need to be passed into the `pleasebuild` command.
+Apart from a GitHub username, you need to provide either a [personal access token](https://github.com/settings/tokens) **or** a password (which is less secure and not recommended).
+
+##### Bitbucket Server #####
+
+When using Bitbucket Server `@include` statements, authentication is optional but is required to access private repositories.
+
+Apart from a Bitbucket Server username, you need to provide either a [personal access token](https://confluence.atlassian.com/bitbucketserver/personal-access-tokens-939515499.html) **or** a password (which is less secure and not recommended).
+
+##### Credentials passing / storing #####
+
+If you are using Builder as a [library](#library-installation), GitHub / Bitbucket Server credentials can be stored using your system's environment variables or in files that store Builder variables. When you are using Builder's [command line tool](#command-line-tool-installation), your credentials will need to be passed into the `pleasebuild` command.
 
 ### @include once ###
 
@@ -742,7 +790,7 @@ This section contains information that will help you work with Builder more effe
 
 ## Reproducible Artifacts ##
 
-It is possible to save the build configuration data used for preprocessing a source file in order to create an identical source file again later with that saved configuration. Builder variable definitions are saved in a [‘directives.json’](#builder-variables-directives) file, and references to the concrete versions of GitHub files and libraries are stored in a [‘dependencies.json’](#github-files-dependencies) file.
+It is possible to save the build configuration data used for preprocessing a source file in order to create an identical source file again later with that saved configuration. Builder variable definitions are saved in a [‘directives.json’](#builder-variables-directives) file, and references to the concrete versions of GitHub / Bitbucket Server files and libraries are stored in a [‘dependencies.json’](#github-and-bitbucket-server-files-dependencies) file.
 
 ### Builder Variables: Directives ###
 
@@ -759,21 +807,24 @@ A typical `directives.json` file looks like this:
 }
 ```
 
-### GitHub Files: Dependencies ###
+### GitHub And Bitbucket Server Files: Dependencies ###
 
-`--save-dependencies [<path_to_file>]` and `--use-dependencies [<path_to_file>]` options are used to save and to reuse, respectively, references to concrete versions of GitHub files and libraries. The references are saved in a JSON file. If a file name is not specified, the `dependencies.json` file in the local directory is used. Every reference consists of GitHub file URL and Git Blob ID (Git Blob SHA). For more information, please see [the Git Manual](https://git-scm.com/book/en/v2/Git-Internals-Git-Objects) and [the Git API](https://developer.github.com/v3/git/blobs/).
-
+`--save-dependencies [<path_to_file>]` and `--use-dependencies [<path_to_file>]` options are used to save and to reuse, respectively, references to concrete versions of GitHub and Bitbucket Server files and libraries. The references are saved in a JSON file. If a file name is not specified, the `dependencies.json` file in the local directory is used. Every reference consists of GitHub / Bitbucket Server file URL and:
+- Git Blob ID (Git Blob SHA) &mdash; for GitHub files<br>
 **Note** It is possible to obtain the Git Blob ID of a GitHub file using the following *git* command: `git hash-object <path_to_file>`
+- Git Commit ID (Git Commit SHA) &mdash; for Bitbucket Server files
+
+For more information, please see [the Git Manual](https://git-scm.com/book/en/v2/Git-Internals-Git-Objects) and [the Git API](https://developer.github.com/v3/git/blobs/).
 
 These options are processed the following way:
 
-- If only `--save-dependencies [<path_to_file>]` is specified, the references to all source files retrieved from GitHub are saved in the provided JSON file (or `dependencies.json`).
-- If only `--use-dependencies [<path_to_file>]` is specified, the source files from GitHub are retrieved using the references read from the provided JSON file (or `dependencies.json`).
+- If only `--save-dependencies [<path_to_file>]` is specified, the references to all source files retrieved from GitHub and Bitbucket Server are saved in the provided JSON file (or `dependencies.json`).
+- If only `--use-dependencies [<path_to_file>]` is specified, the source files from GitHub and Bitbucket Server are retrieved using the references read from the provided JSON file (or `dependencies.json`).
 - If both `--save-dependencies [<path_to_file>]` and `--use-dependencies [<path_to_file>]` are specified, then:
-    1. The source files from GitHub are retrieved using the references read from the JSON file passed to the `--use-dependencies` option (or `dependencies.json`).
-    2. If the source code contains @includes for files from GitHub which have not yet been retrieved, they are retrieved now.
+    1. The source files from GitHub and Bitbucket Server are retrieved using the references read from the JSON file passed to the `--use-dependencies` option (or `dependencies.json`).
+    2. If the source code contains @includes for files from GitHub or Bitbucket Server which have not yet been retrieved, they are retrieved now.
     3. Builder performs the preprocessing operation.
-    4. References to all source files retrieved from GitHub are saved in the JSON file passed to the `--save-dependencies` option (or `dependencies.json`).
+    4. References to all source files retrieved from GitHub and Bitbucket Server are saved in the JSON file passed to the `--save-dependencies` option (or `dependencies.json`).
 
 **Note** If either `--save-dependencies` or `--use-dependencies` is specified, the `--cache` option is ignored.
 
@@ -782,12 +833,16 @@ A typical `dependencies.json` file looks like this:
 ```json
 [
   [
-    "github:repositoryA/ProjectA/fileA",
+    "github:ProjectA/repositoryA/fileA",
     "2ff017dc92e826ad184f9cdeadd1a2446f8d6032"
   ],
   [
-    "github:repositoryB/ProjectB/fileB",
+    "github:ProjectB/repositoryB/fileB",
     "a01b64f9ce764f226f52c6b9364396d4a8bd550b"
+  ],
+  [
+    "bitbucket-server:projectC/repositoryC/fileC",
+    "4bc4024f1f2ad99e8bd2ade73d151912e031d1f5"
   ]
 ]
 ```
@@ -861,7 +916,7 @@ There are a number of advanced techniques you may apply when including remote fi
 
 ### Caching Remote Includes ###
 
-To reduce compilation time, Builder can optionally cache files included from a remote resource (ie. GitHub or remote HTTP/HTTPs servers). If this file cache is enabled, remote files are cached locally in the *.builder-cache* directory. Cached resources expire and are automatically invalidated 24 hours after their addition to the cache.
+To reduce compilation time, Builder can optionally cache files included from a remote resource (ie. GitHub, Bitbucket Server or remote HTTP/HTTPs servers). If this file cache is enabled, remote files are cached locally in the *.builder-cache* directory. Cached resources expire and are automatically invalidated 24 hours after their addition to the cache.
 
 To turn the cache on, pass the `--cache` or `-c` option to Builder. If this option is not specified, Builder will not use the file cache even if the cached data exists and is valid &mdash; it will continue to query remote resources on every execution.
 
@@ -902,7 +957,7 @@ github:*/**/*@*
 
 ### Proxy Access To Remote Includes ###
 
-To specify a proxy that should be used when you are including files from remote resources (ie. GitHub or remote HTTP/HTTPs servers), set the environment variables `HTTP_PROXY`/`http_proxy` and/or `HTTPS_PROXY`/`https_proxy` for HTTP and HTTPS protocols respectively.
+To specify a proxy that should be used when you are including files from remote resources (ie. GitHub, Bitbucket Server or remote HTTP/HTTPs servers), set the environment variables `HTTP_PROXY`/`http_proxy` and/or `HTTPS_PROXY`/`https_proxy` for HTTP and HTTPS protocols respectively.
 
 For example, to operate through a proxy running at IP address 192.168.10.2 on port 3128 for HTTP requests, you should set the environment variable: `HTTP_PROXY='http://192.168.10.2:3128'`. All of Builder’s HTTP requests will now go through the proxy.
 
@@ -916,7 +971,7 @@ If `--use-remote-relative-includes` option is specified, every [local include](#
 
 `--use-remote-relative-includes` option does not affect includes with [absolute remote paths](#include).
 
-**Note** In the current Builder version `--use-remote-relative-includes` option affects includes mentioned in remote source files from GitHub only.
+**Note** In the current Builder version `--use-remote-relative-includes` option affects includes mentioned in remote source files from GitHub and Bitbucket Server only.
 
 # Testing #
 
@@ -928,6 +983,28 @@ SPEC_LOGLEVEL=<debug|info|warning|error>
 SPEC_GITHUB_USERNAME=<GitHub username>
 SPEC_GITHUB_TOKEN=<GitHub password/access token>
 npm test
+```
+
+**Note**: The standard set of tests doesn't include Bitbucket Server integration testing. To run Bitbucket Server tests, please see the section below.
+
+## Bitbucket Server ##
+
+**Prerequisites**:
+1. A running instance of Bitbucket Server
+1. A clone of [Builder](./) repo placed on this server
+1. If the server / repo are not public, an account (username and password / [token](https://confluence.atlassian.com/bitbucketserver/personal-access-tokens-939515499.html)) with permissions to access the repo
+
+```sh
+npm install
+SPEC_LOGLEVEL=<debug|info|warning|error>
+# E.g., "https://bitbucket-srv.itd.example.com"
+SPEC_BITBUCKET_SERVER_ADDRESS=<Bitbucket Server address>
+# Format: "<project>/<repo>". E.g., "myProj/BuilderClone"
+# If the repo belongs to a user (not to a project), the format is: "~<user>/<repo>". E.g., "~john/BuilderClone"
+SPEC_BITBUCKET_SERVER_REPO_PATH=<Path to the cloned Builder repo on the server>
+SPEC_BITBUCKET_SERVER_USERNAME=<Bitbucket Server username>
+SPEC_BITBUCKET_SERVER_TOKEN=<Bitbucket Server password/access token>
+npm run test:bitbucket-server
 ```
 
 # License #

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@
             - [Define A Macro](#define-a-macro)
             - [Use A Macro](#use-a-macro)
         - [@include](#include)
-            - [GitHub Authentication](#github-authentication)
+            - [Authentication](#authentication)
         - [@include once](#include-once)
         - [@while](#while)
         - [@repeat](#repeat)
@@ -42,7 +42,7 @@
 - [Advanced Builder Usage](#advanced-builder-usage)
     - [Reproducible Artifacts](#reproducible-artifacts)
         - [Builder Variables: Directives](#builder-variables-directives)
-        - [GitHub Files: Dependencies](#github-files-dependencies)
+        - [GitHub And Bitbucket Server Files: Dependencies](#github-and-bitbucket-server-files-dependencies)
     - [Including JavaScript Libraries](#including-javascript-libraries)
         - [Binding The Context Object Correctly](#binding-the-context-object-correctly)
     - [Managing Remote Includes](#managing-remote-includes)
@@ -62,7 +62,7 @@ There are a number of ways in which you can [install Builder](#builder-installat
 
 You can use Builder to pull the contents of separate code files into your main source code files. These additional files might contain library code that you make use of across a number of different products, or they might contain confidential data which you don’t want to keep inside source code files that are managed through a software version control system.
 
-You tell Builder which files to import, and where within your main source code they should be inserted, by using the [`@include`](#include) command. Builder is able to access additional files that are stored on your computer or held remotely on a local network file share, on an Internet site or hosted by GitHub.
+You tell Builder which files to import, and where within your main source code they should be inserted, by using the [`@include`](#include) command. Builder is able to access additional files that are stored on your computer or held remotely on a local network file share, on an Internet site or hosted by GitHub or [Bitbucket Server](https://www.atlassian.com/software/bitbucket/download).
 
 While Builder can be used to insert code this way, it can be used in far more sophisticated ways thanks to its integrated expression processor and programming logic. For example, if you need to generate multiple versions of your application firmware for versions of your product which make use of different imp modules, you can use Builder’s [conditional execution features](#if-elif-else), [variables](#variables) and [loops](#while) to pull your various code components together at build time and output files that are ready to be transferred to impCentral.
 
@@ -90,8 +90,8 @@ Now use Builder’s `pleasebuild` command to configure the newly installed utili
 ```sh
 pleasebuild [-l] [-D<variable> <value>]
     [--github-user <username> --github-token <token>]
-    [--lib <path_to_file>]
-    [--use-remote-relative-includes] [--suppress-duplicate-includes-warning]
+    [--bitbucket-server-addr <address>] [--bitbucket-server-user <username> --bitbucket-server-token <token>]
+    [--lib <path_to_file>] [--use-remote-relative-includes] [--suppress-duplicate-includes-warning]
     [--cache] [--clear-cache] [--cache-exclude-list <path_to_file>]
     [--save-dependencies [<path_to_file>]] [--use-dependencies [<path_to_file>]]
     [--save-directives [<path_to_file>]] [--use-directives [<path_to_file>]]
@@ -106,14 +106,17 @@ where `<input_file>` is the path to source file which should be preprocessed and
 | -D&lt;variable&gt; | | No | Yes | Defines a [variable](#variables). May be specified several times to define multiple variables |
 | --github-user | | No | Yes | A GitHub username. |
 | --github-token | | No | Yes | A GitHub [personal access token](https://github.com/settings/tokens) or password (not recommended). Should be specified if the `--github-user` option is specified. |
+| --bitbucket-server-addr | | No | Yes | A Bitbucket Server address. E.g., `https://bitbucket-srv.itd.example.com`. **Note**: this option is mandatory to handle [Bitbucket Server include@ statements](#include-bitbucket) |
+| --bitbucket-server-user | | No | Yes | A Bitbucket Server username. |
+| --bitbucket-server-token | | No | Yes | A Bitbucket Server [personal access token](https://confluence.atlassian.com/bitbucketserver/personal-access-tokens-939515499.html) or password (not recommended). Should be specified if the `--bitbucket-server-user` option is specified. |
 | --lib | --libs | No | Yes | Include the specified [JavaScript file(s) as a library](#including-javascript-libraries). May be specified several times to include multiple libraries. The provided value may specify a concrete file or a directory (all files from the directory will be included). The value may contain [wildcards](https://www.npmjs.com/package/glob) (all matched files will be included) |
 | --use-remote-relative-includes | | No | No | Interpret every [local include](#include) as relative to the location of the source file where it is mentioned. See ['Local Includes From Remote Files'](#local-includes-from-remote-files) |
 | --suppress-duplicate-includes-warning | --suppress-duplicate | No | No | Do not show a warning if a source file with the same content was included multiple times from different locations and this results in code duplication |
 | --cache | -c | No | No | Turn on caching for all files included from remote resources. This option is ignored if the `--save-dependencies` or `--use-dependencies` options are specified. See [‘Caching Remote Includes’](#caching-remote-includes) |
 | --clear-cache | | No | No | Clear the cache before Builder starts running. See [‘Caching Remote Includes’](#caching-remote-includes) |
 | --cache-exclude-list | | No | Yes | Set the path to the file that lists resources which should not be cached. See [‘Caching Remote Includes’](#caching-remote-includes) |
-| --save-dependencies | | No | No | Save references to the required GitHub files in the specified file. If a file name is not specified, the `dependencies.json` file in the local directory is used. See [‘Reproducible Artifacts’](#reproducible-artifacts) |
-| --use-dependencies | | No | No | Use the specified file to set which GitHub files are required. If a file name is not specified, the `dependencies.json` file in the local directory is used. See [‘Reproducible Artifacts’](#reproducible-artifacts).  |
+| --save-dependencies | | No | No | Save references to the required GitHub/Bitbucket files in the specified file. If a file name is not specified, the `dependencies.json` file in the local directory is used. See [‘Reproducible Artifacts’](#reproducible-artifacts) |
+| --use-dependencies | | No | No | Use the specified file to set which GitHub/Bitbucket files are required. If a file name is not specified, the `dependencies.json` file in the local directory is used. See [‘Reproducible Artifacts’](#reproducible-artifacts).  |
 | --save-directives | | No | No | Save Builder variable definitions in the specified file. If a file name is not specified, the `directives.json` file in the local directory is used. See [‘Reproducible Artifacts’](#reproducible-artifacts) |
 | --use-directives | | No | No | Use Builder variable definitions from the specified file. If a file name is not specified, the `directives.json` file in the local directory is used. See [‘Reproducible Artifacts’](#reproducible-artifacts) |
 
@@ -141,11 +144,16 @@ builder.machine.useCache = <true|false>;
 builder.machine.readers.github.username = "<USERNAME>";
 builder.machine.readers.github.token = "<PASSWORD_OR_ACCESS_TOKEN>";
 
+// Set Bitbucket Server address and credentials. See the "--bitbucket-server-*" CLI options.
+builder.machine.readers.bitbucketSrv.serverAddr = "<ADDRESS>";
+builder.machine.readers.bitbucketSrv.username = "<USERNAME>";
+builder.machine.readers.bitbucketSrv.token = "<PASSWORD_OR_ACCESS_TOKEN>";
+
 // Path to the file that lists the resources which should be excluded from caching.
 // See the "--cache-exclude-list" CLI option.
 builder.machine.excludeList = "<PATH_TO_FILE>";
 
-// Replace local include paths to github URLs if requested.
+// Replace local include paths to github/bitbucket URLs if requested.
 // See the "--use-remote-relative-includes" CLI option.
 builder.machine.remoteRelativeIncludes = <true|false>;
 
@@ -524,9 +532,33 @@ This directive can be used to include local files, external sources or [macros](
 
         <pre><b>@include</b> "github:electricimp/Promise/promise.class.nut@develop"</pre>
 
-    - Tag _v3.0.1_:
+    - Tag _v3.0.1_
 
         <pre><b>@include</b> "github:electricimp/Promise/promise.class.nut@v3.0.1"</pre>
+<a id='include-bitbucket'></a>        
+- For Bitbucket Server file, where:
+
+    - `project` is the project name (needed to include source files from project repos).
+    - `user` is the user name (needed to include source files from personal repos). **Note:** user name must be prepended with `~`. E.g., your user name is John - then you should write `~john`.
+    - `repo` is the repository name.
+    - `ref` is the git reference (branch name or tag, defaults to _master_).
+
+    <pre>// Include a source file from a project repo
+  <b>@include</b> "bitbucket-server:<i>&lt;project&gt;</i>/<i>&lt;repo&gt;</i>/<i>&lt;path&gt;</i>[@<i>&lt;ref&gt;</i>]"
+  // Include a source file from a personal repo
+  <b>@include</b> "bitbucket-server:<i>~&lt;user&gt;</i>/<i>&lt;repo&gt;</i>/<i>&lt;path&gt;</i>[@<i>&lt;ref&gt;</i>]"</pre>
+
+    - Head of the default branch
+
+        <pre><b>@include</b> "bitbucket-server:Tools/Promise/promise.class.nut"</pre>
+
+    - Head of the _develop_ branch
+
+        <pre><b>@include</b> "bitbucket-server:Tools/Promise/promise.class.nut@develop"</pre>
+
+    - Tag _v3.0.1_ (personal repo)
+
+        <pre><b>@include</b> "bitbucket-server:~john/Promise/promise.class.nut@v3.0.1"</pre>
 
 The `@include` directive can be combined with the `__PATH__` [variable](#builder-variables) to build references to your files.
 
@@ -537,14 +569,26 @@ The `@include` directive can be combined with the `__PATH__` [variable](#builder
 @include __PATH__ + "/../shared/Constants.shared.nut"
 ```
 
-#### GitHub Authentication ####
+#### Authentication ####
+
+##### GitHub #####
 
 When using GitHub `@include` statements, authentication is optional. However, you should bear in mind that:
 
 - If you use authentication, the GitHub API provides much higher rate limits.
 - Authentication is required to access private repositories.
 
-Apart from a GitHub username, you need to provide either a [personal access token](https://github.com/settings/tokens) **or** a password (which is less secure and not recommended). If you are using Builder as a [library](#library-installation), GitHub credentials can be stored using your system's environment variables or in files that store Builder variables. When you are using Builder's [command line tool](#command-line-tool-installation), your GitHub credentials will need to be passed into the `pleasebuild` command.
+Apart from a GitHub username, you need to provide either a [personal access token](https://github.com/settings/tokens) **or** a password (which is less secure and not recommended).
+
+##### Bitbucket Server #####
+
+When using Bitbucket Server `@include` statements, authentication is optional but is required to access private repositories.
+
+Apart from a Bitbucket Server username, you need to provide either a [personal access token](https://confluence.atlassian.com/bitbucketserver/personal-access-tokens-939515499.html) **or** a password (which is less secure and not recommended).
+
+##### Credentials passing / storing #####
+
+If you are using Builder as a [library](#library-installation), GitHub / Bitbucket Server credentials can be stored using your system's environment variables or in files that store Builder variables. When you are using Builder's [command line tool](#command-line-tool-installation), your credentials will need to be passed into the `pleasebuild` command.
 
 ### @include once ###
 
@@ -742,7 +786,7 @@ This section contains information that will help you work with Builder more effe
 
 ## Reproducible Artifacts ##
 
-It is possible to save the build configuration data used for preprocessing a source file in order to create an identical source file again later with that saved configuration. Builder variable definitions are saved in a [‘directives.json’](#builder-variables-directives) file, and references to the concrete versions of GitHub files and libraries are stored in a [‘dependencies.json’](#github-files-dependencies) file.
+It is possible to save the build configuration data used for preprocessing a source file in order to create an identical source file again later with that saved configuration. Builder variable definitions are saved in a [‘directives.json’](#builder-variables-directives) file, and references to the concrete versions of GitHub / Bitbucket Server files and libraries are stored in a [‘dependencies.json’](#github-and-bitbucket-server-files-dependencies) file.
 
 ### Builder Variables: Directives ###
 
@@ -759,21 +803,24 @@ A typical `directives.json` file looks like this:
 }
 ```
 
-### GitHub Files: Dependencies ###
+### GitHub And Bitbucket Server Files: Dependencies ###
 
-`--save-dependencies [<path_to_file>]` and `--use-dependencies [<path_to_file>]` options are used to save and to reuse, respectively, references to concrete versions of GitHub files and libraries. The references are saved in a JSON file. If a file name is not specified, the `dependencies.json` file in the local directory is used. Every reference consists of GitHub file URL and Git Blob ID (Git Blob SHA). For more information, please see [the Git Manual](https://git-scm.com/book/en/v2/Git-Internals-Git-Objects) and [the Git API](https://developer.github.com/v3/git/blobs/).
-
+`--save-dependencies [<path_to_file>]` and `--use-dependencies [<path_to_file>]` options are used to save and to reuse, respectively, references to concrete versions of GitHub and Bitbucket Server files and libraries. The references are saved in a JSON file. If a file name is not specified, the `dependencies.json` file in the local directory is used. Every reference consists of GitHub / Bitbucket Server file URL and:
+- Git Blob ID (Git Blob SHA) &mdash; for GitHub files<br>
 **Note** It is possible to obtain the Git Blob ID of a GitHub file using the following *git* command: `git hash-object <path_to_file>`
+- Git Commit ID (Git Commit SHA) &mdash; for Bitbucket Server files
+
+For more information, please see [the Git Manual](https://git-scm.com/book/en/v2/Git-Internals-Git-Objects) and [the Git API](https://developer.github.com/v3/git/blobs/).
 
 These options are processed the following way:
 
-- If only `--save-dependencies [<path_to_file>]` is specified, the references to all source files retrieved from GitHub are saved in the provided JSON file (or `dependencies.json`).
-- If only `--use-dependencies [<path_to_file>]` is specified, the source files from GitHub are retrieved using the references read from the provided JSON file (or `dependencies.json`).
+- If only `--save-dependencies [<path_to_file>]` is specified, the references to all source files retrieved from GitHub and Bitbucket Server are saved in the provided JSON file (or `dependencies.json`).
+- If only `--use-dependencies [<path_to_file>]` is specified, the source files from GitHub and Bitbucket Server are retrieved using the references read from the provided JSON file (or `dependencies.json`).
 - If both `--save-dependencies [<path_to_file>]` and `--use-dependencies [<path_to_file>]` are specified, then:
-    1. The source files from GitHub are retrieved using the references read from the JSON file passed to the `--use-dependencies` option (or `dependencies.json`).
-    2. If the source code contains @includes for files from GitHub which have not yet been retrieved, they are retrieved now.
+    1. The source files from GitHub and Bitbucket Server are retrieved using the references read from the JSON file passed to the `--use-dependencies` option (or `dependencies.json`).
+    2. If the source code contains @includes for files from GitHub or Bitbucket Server which have not yet been retrieved, they are retrieved now.
     3. Builder performs the preprocessing operation.
-    4. References to all source files retrieved from GitHub are saved in the JSON file passed to the `--save-dependencies` option (or `dependencies.json`).
+    4. References to all source files retrieved from GitHub and Bitbucket Server are saved in the JSON file passed to the `--save-dependencies` option (or `dependencies.json`).
 
 **Note** If either `--save-dependencies` or `--use-dependencies` is specified, the `--cache` option is ignored.
 
@@ -782,12 +829,16 @@ A typical `dependencies.json` file looks like this:
 ```json
 [
   [
-    "github:repositoryA/ProjectA/fileA",
+    "github:ProjectA/repositoryA/fileA",
     "2ff017dc92e826ad184f9cdeadd1a2446f8d6032"
   ],
   [
-    "github:repositoryB/ProjectB/fileB",
+    "github:ProjectB/repositoryB/fileB",
     "a01b64f9ce764f226f52c6b9364396d4a8bd550b"
+  ],
+  [
+    "bitbucket-server:projectC/repositoryC/fileC",
+    "4bc4024f1f2ad99e8bd2ade73d151912e031d1f5"
   ]
 ]
 ```
@@ -861,7 +912,7 @@ There are a number of advanced techniques you may apply when including remote fi
 
 ### Caching Remote Includes ###
 
-To reduce compilation time, Builder can optionally cache files included from a remote resource (ie. GitHub or remote HTTP/HTTPs servers). If this file cache is enabled, remote files are cached locally in the *.builder-cache* directory. Cached resources expire and are automatically invalidated 24 hours after their addition to the cache.
+To reduce compilation time, Builder can optionally cache files included from a remote resource (ie. GitHub, Bitbucket Server or remote HTTP/HTTPs servers). If this file cache is enabled, remote files are cached locally in the *.builder-cache* directory. Cached resources expire and are automatically invalidated 24 hours after their addition to the cache.
 
 To turn the cache on, pass the `--cache` or `-c` option to Builder. If this option is not specified, Builder will not use the file cache even if the cached data exists and is valid &mdash; it will continue to query remote resources on every execution.
 
@@ -902,7 +953,7 @@ github:*/**/*@*
 
 ### Proxy Access To Remote Includes ###
 
-To specify a proxy that should be used when you are including files from remote resources (ie. GitHub or remote HTTP/HTTPs servers), set the environment variables `HTTP_PROXY`/`http_proxy` and/or `HTTPS_PROXY`/`https_proxy` for HTTP and HTTPS protocols respectively.
+To specify a proxy that should be used when you are including files from remote resources (ie. GitHub, Bitbucket Server or remote HTTP/HTTPs servers), set the environment variables `HTTP_PROXY`/`http_proxy` and/or `HTTPS_PROXY`/`https_proxy` for HTTP and HTTPS protocols respectively.
 
 For example, to operate through a proxy running at IP address 192.168.10.2 on port 3128 for HTTP requests, you should set the environment variable: `HTTP_PROXY='http://192.168.10.2:3128'`. All of Builder’s HTTP requests will now go through the proxy.
 
@@ -916,7 +967,7 @@ If `--use-remote-relative-includes` option is specified, every [local include](#
 
 `--use-remote-relative-includes` option does not affect includes with [absolute remote paths](#include).
 
-**Note** In the current Builder version `--use-remote-relative-includes` option affects includes mentioned in remote source files from GitHub only.
+**Note** In the current Builder version `--use-remote-relative-includes` option affects includes mentioned in remote source files from GitHub and Bitbucket Server only.
 
 # Testing #
 
@@ -928,6 +979,28 @@ SPEC_LOGLEVEL=<debug|info|warning|error>
 SPEC_GITHUB_USERNAME=<GitHub username>
 SPEC_GITHUB_TOKEN=<GitHub password/access token>
 npm test
+```
+
+**Note**: The standard set of tests doesn't include Bitbucket Server integration testing. To run Bitbucket Server tests, please see the section below.
+
+## Bitbucket Server ##
+
+**Prerequisites**:
+1. A running instance of Bitbucket Server
+1. A clone of [Builder](./) repo placed on this server
+1. If the server / repo are not public, an account (username and password / [token](https://confluence.atlassian.com/bitbucketserver/personal-access-tokens-939515499.html)) with permissions to access the repo
+
+```sh
+npm install
+SPEC_LOGLEVEL=<debug|info|warning|error>
+# E.g., "https://bitbucket-srv.itd.example.com"
+SPEC_BITBUCKET_SERVER_ADDRESS=<Bitbucket Server address>
+# Format: "<project>/<repo>". E.g., "myProj/BuilderClone"
+# If the repo belongs to a user (not to a project), the format is: "~<user>/<repo>". E.g., "~john/BuilderClone"
+SPEC_BITBUCKET_SERVER_REPO_PATH=<Path to the cloned Builder repo on the server>
+SPEC_BITBUCKET_SERVER_USERNAME=<Bitbucket Server username>
+SPEC_BITBUCKET_SERVER_TOKEN=<Bitbucket Server password/access token>
+npm run test:bitbucket-server
 ```
 
 # License #

--- a/README.md
+++ b/README.md
@@ -535,8 +535,8 @@ This directive can be used to include local files, external sources or [macros](
     - Tag _v3.0.1_
 
         <pre><b>@include</b> "github:electricimp/Promise/promise.class.nut@v3.0.1"</pre>
-<a id='include-bitbucket'></a>        
-- For Bitbucket Server file, where:
+<a id='include-bitbucket'></a>
+- For [Bitbucket Server](#include-bitbucket-note1) file, where:
 
     - `project` is the project name (needed to include source files from project repos).
     - `user` is the user name (needed to include source files from personal repos). **Note:** user name must be prepended with `~`. E.g., your user name is John - then you should write `~john`.
@@ -559,8 +559,10 @@ This directive can be used to include local files, external sources or [macros](
     - Tag _v3.0.1_ (personal repo)
 
         <pre><b>@include</b> "bitbucket-server:~john/Promise/promise.class.nut@v3.0.1"</pre>
+    <a id='include-bitbucket-note1'></a>
+    **Note 1**: This section describes [**Bitbucket Server**](https://www.atlassian.com/software/bitbucket/download) includes. You can't use this to include files from [Bitbucket.org](https://bitbucket.org/).
 
-    **Note**: Currently, only one server can be specified/used to fetch all Bitbucket Server includes.
+    **Note 2**: Currently, only one server can be specified/used to fetch all Bitbucket Server includes.
 
 The `@include` directive can be combined with the `__PATH__` [variable](#builder-variables) to build references to your files.
 

--- a/README.md
+++ b/README.md
@@ -532,30 +532,21 @@ This directive can be used to include local files, external sources or [macros](
 
         <pre><b>@include</b> "github:electricimp/Promise/promise.class.nut@develop"</pre>
 
-    - Tag _v3.0.1_:
+    - Tag _v3.0.1_
 
         <pre><b>@include</b> "github:electricimp/Promise/promise.class.nut@v3.0.1"</pre>
         
 - For Bitbucket Server file, where:
 
-    - `project/user` is the project/user name. **Note:** user name must be prepended with `~`. E.g., your user name is John - then you should write `~john`. This doesn't apply to project names.
+    - `project` is the project name (needed to include source files from project repos).
+    - `user` is the user name (needed to include source files from personal repos). **Note:** user name must be prepended with `~`. E.g., your user name is John - then you should write `~john`.
     - `repo` is the repository name.
     - `ref` is the git reference (branch name or tag, defaults to _master_).
 
-    <pre><b>@include</b> "bitbucket-server:<i>&lt;project&gt;</i>/<i>&lt;repo&gt;</i>/<i>&lt;path&gt;</i>[@<i>&lt;ref&gt;</i>]"</pre>
-
-
-    - `project` is the project name.
-    - `~user` is the user name. **Note:** user name must be prepended with `~`. E.g., your user name is John - then you should write `~john`.
-    - `repo` is the repository name.
-    - `ref` is the git reference (branch name or tag, defaults to _master_).
-<pre>// Include a source file from a project
-<b>@include</b> "bitbucket-server:<i>&lt;project&gt;</i>/<i>&lt;repo&gt;</i>/<i>&lt;path&gt;</i>[@<i>&lt;ref&gt;</i>]"
-// Include a source file from a personal repo
-<b>@include</b> "bitbucket-server:<i>&lt;~user&gt;</i>/<i>&lt;repo&gt;</i>/<i>&lt;path&gt;</i>[@<i>&lt;ref&gt;</i>]"</pre>
-
-
-
+    <pre>// Include a source file from a project repo
+  <b>@include</b> "bitbucket-server:<i>&lt;project&gt;</i>/<i>&lt;repo&gt;</i>/<i>&lt;path&gt;</i>[@<i>&lt;ref&gt;</i>]"
+  // Include a source file from a personal repo
+  <b>@include</b> "bitbucket-server:<i>~&lt;user&gt;</i>/<i>&lt;repo&gt;</i>/<i>&lt;path&gt;</i>[@<i>&lt;ref&gt;</i>]"</pre>
 
     - Head of the default branch
 
@@ -565,9 +556,9 @@ This directive can be used to include local files, external sources or [macros](
 
         <pre><b>@include</b> "bitbucket-server:Tools/Promise/promise.class.nut@develop"</pre>
 
-    - Tag _v3.0.1_:
+    - Tag _v3.0.1_ (personal repo)
 
-        <pre><b>@include</b> "bitbucket-server:Tools/Promise/promise.class.nut@v3.0.1"</pre>
+        <pre><b>@include</b> "bitbucket-server:~john/Promise/promise.class.nut@v3.0.1"</pre>
 
 The `@include` directive can be combined with the `__PATH__` [variable](#builder-variables) to build references to your files.
 
@@ -578,14 +569,26 @@ The `@include` directive can be combined with the `__PATH__` [variable](#builder
 @include __PATH__ + "/../shared/Constants.shared.nut"
 ```
 
-#### GitHub Authentication ####
+#### Authentication ####
+
+##### GitHub #####
 
 When using GitHub `@include` statements, authentication is optional. However, you should bear in mind that:
 
 - If you use authentication, the GitHub API provides much higher rate limits.
 - Authentication is required to access private repositories.
 
-Apart from a GitHub username, you need to provide either a [personal access token](https://github.com/settings/tokens) **or** a password (which is less secure and not recommended). If you are using Builder as a [library](#library-installation), GitHub credentials can be stored using your system's environment variables or in files that store Builder variables. When you are using Builder's [command line tool](#command-line-tool-installation), your GitHub credentials will need to be passed into the `pleasebuild` command.
+Apart from a GitHub username, you need to provide either a [personal access token](https://github.com/settings/tokens) **or** a password (which is less secure and not recommended).
+
+##### Bitbucket Server #####
+
+When using Bitbucket Server `@include` statements, authentication is optional but is required to access private repositories.
+
+Apart from a Bitbucket Server username, you need to provide either a [personal access token](https://confluence.atlassian.com/bitbucketserver/personal-access-tokens-939515499.html) **or** a password (which is less secure and not recommended).
+
+##### Credentials passing / storing #####
+
+If you are using Builder as a [library](#library-installation), GitHub / Bitbucket Server credentials can be stored using your system's environment variables or in files that store Builder variables. When you are using Builder's [command line tool](#command-line-tool-installation), your credentials will need to be passed into the `pleasebuild` command.
 
 ### @include once ###
 

--- a/README.md
+++ b/README.md
@@ -806,9 +806,9 @@ A typical `directives.json` file looks like this:
 ### GitHub And Bitbucket Server Files: Dependencies ###
 
 `--save-dependencies [<path_to_file>]` and `--use-dependencies [<path_to_file>]` options are used to save and to reuse, respectively, references to concrete versions of GitHub and Bitbucket Server files and libraries. The references are saved in a JSON file. If a file name is not specified, the `dependencies.json` file in the local directory is used. Every reference consists of GitHub / Bitbucket Server file URL and:
-- For GitHub: Git Blob ID (Git Blob SHA)<br>
+- Git Blob ID (Git Blob SHA) &mdash; for GitHub files<br>
 **Note** It is possible to obtain the Git Blob ID of a GitHub file using the following *git* command: `git hash-object <path_to_file>`
-- For Bitbucket Server: Git Commit ID (Git Commit SHA)
+- Git Commit ID (Git Commit SHA) &mdash; for Bitbucket Server files
 
 For more information, please see [the Git Manual](https://git-scm.com/book/en/v2/Git-Internals-Git-Objects) and [the Git API](https://developer.github.com/v3/git/blobs/).
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <img src=docs/logo.png?2 width=180 alt=Builder><br />
 
-### Current version: 2.8.1 ###
+### Current version: 2.9.0 ###
 
 ![Build Status](https://cse-ci.electricimp.com/app/rest/builds/buildType:(id:Builder_BuildAndTest)/statusIcon)
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@
             - [Define A Macro](#define-a-macro)
             - [Use A Macro](#use-a-macro)
         - [@include](#include)
-            - [GitHub Authentication](#github-authentication)
+            - [Authentication](#authentication)
         - [@include once](#include-once)
         - [@while](#while)
         - [@repeat](#repeat)
@@ -786,7 +786,7 @@ This section contains information that will help you work with Builder more effe
 
 ## Reproducible Artifacts ##
 
-It is possible to save the build configuration data used for preprocessing a source file in order to create an identical source file again later with that saved configuration. Builder variable definitions are saved in a [‘directives.json’](#builder-variables-directives) file, and references to the concrete versions of GitHub files and libraries are stored in a [‘dependencies.json’](#github-files-dependencies) file.
+It is possible to save the build configuration data used for preprocessing a source file in order to create an identical source file again later with that saved configuration. Builder variable definitions are saved in a [‘directives.json’](#builder-variables-directives) file, and references to the concrete versions of GitHub / Bitbucket Server files and libraries are stored in a [‘dependencies.json’](#github-files-dependencies) file.
 
 ### Builder Variables: Directives ###
 

--- a/README.md
+++ b/README.md
@@ -560,6 +560,8 @@ This directive can be used to include local files, external sources or [macros](
 
         <pre><b>@include</b> "bitbucket-server:~john/Promise/promise.class.nut@v3.0.1"</pre>
 
+    **Note**: Currently, only one server can be specified/used to fetch all Bitbucket Server includes.
+
 The `@include` directive can be combined with the `__PATH__` [variable](#builder-variables) to build references to your files.
 
 ```

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "Builder",
-  "version": "2.8.1",
+  "version": "2.9.0",
   "description": "Builder Language Implementation",
   "main": "src/index.js",
   "bin": {
@@ -8,6 +8,7 @@
   },
   "scripts": {
     "test": "jasmine",
+    "test:bitbucket-server": "node ./spec/BitbucketServerExecutor.js",
     "build": "src/cli.js input"
   },
   "repository": {
@@ -35,7 +36,7 @@
     "upath": "^1.1.2"
   },
   "devDependencies": {
-    "jasmine": "^2.4.1",
+    "jasmine": "^3.5.0",
     "jasmine-expect": "^2.0.2",
     "log": "^1.4.0",
     "eol": "^0.9.1",

--- a/spec/BitbucketServer/BitbucketServerReader.spec.js
+++ b/spec/BitbucketServer/BitbucketServerReader.spec.js
@@ -1,0 +1,66 @@
+// MIT License
+//
+// Copyright 2019 Electric Imp
+//
+// SPDX-License-Identifier: MIT
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO
+// EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES
+// OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+// ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+// OTHER DEALINGS IN THE SOFTWARE.
+
+'use strict';
+
+const fs = require('fs');
+const Log = require('log');
+const eol = require('eol');
+const BitbucketServerReader = require('../../src/Readers/BitbucketServerReader');
+
+describe('BitbucketServerReader', () => {
+  let reader;
+
+  beforeEach(function() {
+    if (!(process.env.SPEC_BITBUCKET_SERVER_ADDRESS && process.env.SPEC_BITBUCKET_SERVER_REPO_PATH)) {
+      fail('Some of the required environment variables are not set');
+      return;
+    }
+
+    reader = new BitbucketServerReader();
+
+    // @see https://www.npmjs.com/package/log#log-levels
+    reader.logger = new Log(process.env.SPEC_LOGLEVEL || 'error');
+    reader.serverAddr = process.env.SPEC_BITBUCKET_SERVER_ADDRESS;
+    reader.username = process.env.SPEC_BITBUCKET_SERVER_USERNAME;
+    reader.password = process.env.SPEC_BITBUCKET_SERVER_PASSWORD || process.env.SPEC_BITBUCKET_SERVER_TOKEN;
+  });
+
+  it('should read sample#1 from Bitbucket server', () => {
+    let remote;
+    const local = eol.lf(fs.readFileSync(__dirname + '/../fixtures/sample-1/input.nut', 'utf-8'));
+
+    remote = reader.read(`bitbucket-server:${process.env.SPEC_BITBUCKET_SERVER_REPO_PATH}/spec/fixtures/sample-1/input.nut@master`);
+    expect(remote).toEqual(local);
+
+    remote = reader.read(`bitbucket-server:${process.env.SPEC_BITBUCKET_SERVER_REPO_PATH}/spec/fixtures/sample-1/input.nut`);
+    expect(remote).toEqual(local);
+
+    remote = reader.read(`bitbucket-server:${process.env.SPEC_BITBUCKET_SERVER_REPO_PATH}/./spec/../spec/fixtures/sample-1/input.nut`);
+    expect(remote).toEqual(local);
+
+    remote = reader.read(`bitbucket-server:${process.env.SPEC_BITBUCKET_SERVER_REPO_PATH}/./spec/../spec/fixtures/sample-1/input.nut@master`);
+    expect(remote).toEqual(local);
+  });
+});

--- a/spec/BitbucketServer/cache.spec.js
+++ b/spec/BitbucketServer/cache.spec.js
@@ -1,0 +1,101 @@
+// MIT License
+//
+// Copyright 2019 Electric Imp
+//
+// SPDX-License-Identifier: MIT
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO
+// EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES
+// OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+// ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+// OTHER DEALINGS IN THE SOFTWARE.
+
+'use strict';
+
+require('jasmine-expect');
+
+const fs = require('fs');
+const Log = require('log');
+const Builder = require('../../src/');
+
+describe('FileCache', () => {
+  let machine;
+
+  beforeEach(() => {
+    if (!(process.env.SPEC_BITBUCKET_SERVER_ADDRESS && process.env.SPEC_BITBUCKET_SERVER_REPO_PATH)) {
+      fail('Some of the required environment variables are not set');
+      return;
+    }
+
+    const builder = new Builder();
+    builder.logger = new Log(process.env.SPEC_LOGLEVEL || 'error');
+    builder.machine.readers.bitbucketSrv.serverAddr = process.env.SPEC_BITBUCKET_SERVER_ADDRESS;
+    builder.machine.readers.bitbucketSrv.username = process.env.SPEC_BITBUCKET_SERVER_USERNAME;
+    builder.machine.readers.bitbucketSrv.token = process.env.SPEC_BITBUCKET_SERVER_PASSWORD || process.env.SPEC_BITBUCKET_SERVER_TOKEN;
+    machine = builder.machine;
+    machine.fileCache.cacheDir = './test-cache';
+  });
+
+  afterEach(() => {
+    if (!machine) {
+      return;
+    }
+
+    if (fs.existsSync(machine.fileCache.cacheDir)) {
+      machine.clearCache();
+    }
+  });
+
+  it('should not read cached files when cache option is off', () => {
+    let link = `bitbucket-server:${process.env.SPEC_BITBUCKET_SERVER_REPO_PATH}/spec/fixtures/sample-11/LineBrakeSample.nut`;
+    machine.useCache = false;
+    machine.fileCache._cacheFile(link, 'cached');
+    expect(machine.execute(`@include '${link}'`)).not.toEqual('cached');
+  });
+
+  it('should cache files in machine', () => {
+    let link = `bitbucket-server:${process.env.SPEC_BITBUCKET_SERVER_REPO_PATH}/spec/fixtures/sample-11/LineBrakeSample.nut`;
+    machine.useCache = true;
+    machine.execute(`@include '${link}'`);
+    expect(machine.fileCache._findFile(link)).toBeTruthy();
+  });
+
+  it('should exclude remote files from cache', () => {
+    machine.useCache = true;
+    let linkName = `bitbucket-server:${process.env.SPEC_BITBUCKET_SERVER_REPO_PATH}/spec/fixtures/sample-11/LineBrakeSample.nut`;
+    expect(machine.fileCache._findFile(linkName)).toEqual(false);
+    machine.excludeList = __dirname + '/../fixtures/config/exclude-all.exclude';
+    machine.execute(`@include '${linkName}'`);
+    expect(machine.fileCache._findFile(linkName)).toEqual(false);
+  });
+
+  it('should generate unique paths for different bitbucket-server links', () => {
+    const linksSet = new Set();
+    const links = ['bitbucket-server:a/b/c.js',
+                   'bitbucket-server:b/a/c.js',
+                   'bitbucket-server:a/b/c.js@a',
+                   'bitbucket-server:a/b/c.j@s',
+                   'bitbucket-server:a/b/a-b-c.js',
+                   'bitbucket-server:a/b-c_js/c.js',
+                   'bitbucket-server:a/b/c_js.js',
+                   'bitbucket-server:a/b/c/js'
+                  ];
+    links.forEach(link => {
+      const path = machine.fileCache._getCachedPath(link);
+      expect(linksSet.has(path)).toEqual(false);
+      linksSet.add(path);
+    });
+  });
+});

--- a/spec/BitbucketServer/dependencies.spec.js
+++ b/spec/BitbucketServer/dependencies.spec.js
@@ -1,0 +1,89 @@
+// MIT License
+//
+// Copyright 2019 Electric Imp
+//
+// SPDX-License-Identifier: MIT
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO
+// EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES
+// OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+// ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+// OTHER DEALINGS IN THE SOFTWARE.
+
+'use strict';
+
+require('jasmine-expect');
+
+const fs = require('fs');
+const path = require('path');
+const eol = require('eol');
+const Log = require('log');
+const Builder = require('../../src/');
+
+const dependenciesFile = path.join(process.cwd(), 'save_dependencies.json');
+
+describe('Machine', () => {
+  let machine;
+
+  beforeEach(function () {
+    if (!(process.env.SPEC_BITBUCKET_SERVER_ADDRESS && process.env.SPEC_BITBUCKET_SERVER_REPO_PATH)) {
+      fail('Some of the required environment variables are not set');
+      return;
+    }
+
+    const builder = new Builder();
+    builder.logger = new Log(process.env.SPEC_LOGLEVEL || 'error');
+    builder.machine.readers.bitbucketSrv.serverAddr = process.env.SPEC_BITBUCKET_SERVER_ADDRESS;
+    builder.machine.readers.bitbucketSrv.username = process.env.SPEC_BITBUCKET_SERVER_USERNAME;
+    builder.machine.readers.bitbucketSrv.token = process.env.SPEC_BITBUCKET_SERVER_PASSWORD || process.env.SPEC_BITBUCKET_SERVER_TOKEN;
+    machine = builder.machine;
+  });
+
+  it('Create and read dependencies JSON file', () => {
+    const rev1CommitID = "618bb5ecb831762ed085486f39496502f7b22700";
+    const rev1Content = "// included file a\n// included file b\n\n\n  // should be included\n\n    // l2 else\n\n\n  // should be included\n";
+    const rev0CommitID = "e2a5b434b34b5737b2ff52f51a92c5bbcc9f83bf";
+    const rev0Content = "// included file a\n    // included file b\n\n\n      // should be included\n\n        // l2 else\n\n\n      // should be included\n";
+    const url = `bitbucket-server:${process.env.SPEC_BITBUCKET_SERVER_REPO_PATH}/spec/fixtures/sample-1/input.nut.out@v2.2.2`;
+
+    // ensure that test dependencies JSON file does not exist
+    if (fs.existsSync(dependenciesFile)) {
+      fs.unlinkSync(dependenciesFile);
+    }
+
+    machine.dependenciesSaveFile = dependenciesFile;
+    expect(eol.lf(machine.execute(`@include "${url}"`))).toBe(rev1Content);
+
+    // check dependencies JSON file content
+    const rev1Map = new Map(JSON.parse(fs.readFileSync(dependenciesFile)));
+    expect(rev1Map.size).toEqual(1);
+    expect(rev1Map.get(url)).toEqual(rev1CommitID);
+
+    // replace the actual (rev1) commit ID to rev0 commit ID
+    rev1Map.set(url, rev0CommitID);
+    fs.writeFileSync(dependenciesFile, JSON.stringify([...rev1Map], null, 2), 'utf-8');
+
+    machine.dependenciesUseFile = dependenciesFile;
+    expect(eol.lf(machine.execute(`@include "${url}"`))).toBe(rev0Content);
+
+    // check dependencies JSON file content again
+    const rev0Map = new Map(JSON.parse(fs.readFileSync(dependenciesFile)));
+    expect(rev0Map.size).toEqual(1);
+    expect(rev0Map.get(url)).toEqual(rev0CommitID);
+
+    // unlink dependencies file to avoid conflicts with unit-tests below
+    fs.unlinkSync(dependenciesFile);
+  });
+});

--- a/spec/BitbucketServer/remote-relative-includes.spec.js
+++ b/spec/BitbucketServer/remote-relative-includes.spec.js
@@ -1,0 +1,68 @@
+// MIT License
+//
+// Copyright 2019 Electric Imp
+//
+// SPDX-License-Identifier: MIT
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO
+// EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES
+// OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+// ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+// OTHER DEALINGS IN THE SOFTWARE.
+
+'use strict';
+
+// require('jasmine-expect');
+
+const eol = require('eol');
+const Log = require('log');
+const backslashToSlash = require('../backslashToSlash');
+const Builder = require('../../src/');
+
+// File inc-a.nut contains `@include "inc-b.nut"`
+const bitbucketPathA = `bitbucket-server:${process.env.SPEC_BITBUCKET_SERVER_REPO_PATH}/spec/fixtures/sample-1/inc-a.nut`;
+
+describe('remote-relative-includes', () => {
+  let machine;
+
+  beforeEach(function () {
+    if (!(process.env.SPEC_BITBUCKET_SERVER_ADDRESS && process.env.SPEC_BITBUCKET_SERVER_REPO_PATH)) {
+      fail('Some of the required environment variables are not set');
+      return;
+    }
+
+    const builder = new Builder();
+    builder.logger = new Log(process.env.SPEC_LOGLEVEL || 'error');
+    builder.machine.readers.bitbucketSrv.serverAddr = process.env.SPEC_BITBUCKET_SERVER_ADDRESS;
+    builder.machine.readers.bitbucketSrv.username = process.env.SPEC_BITBUCKET_SERVER_USERNAME;
+    builder.machine.readers.bitbucketSrv.token = process.env.SPEC_BITBUCKET_SERVER_PASSWORD || process.env.SPEC_BITBUCKET_SERVER_TOKEN;
+    machine = builder.machine;
+  });
+
+  it('fetch local include from Bitbucket server', () => {
+    const fileNotFoundMessage = `Local file "inc-b.nut" not found (${bitbucketPathA}:2)`;
+    try {
+      eol.lf(machine.execute(`@include once "${bitbucketPathA}"`));
+      fail();
+    } catch (e) {
+      expect(backslashToSlash(e.message)).toEqual(fileNotFoundMessage);
+    }
+
+    // Enable remote-relative-includes feature
+    machine.remoteRelativeIncludes = true;
+    const res = eol.lf(machine.execute(`@include once "${bitbucketPathA}"`));
+    expect(res).toEqual('// included file a\n// included file b\n');
+  });
+});

--- a/spec/BitbucketServerExecutor.js
+++ b/spec/BitbucketServerExecutor.js
@@ -1,0 +1,36 @@
+// MIT License
+//
+// Copyright 2019 Electric Imp
+//
+// SPDX-License-Identifier: MIT
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO
+// EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES
+// OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+// ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+// OTHER DEALINGS IN THE SOFTWARE.
+
+const Jasmine = require('jasmine');
+
+const jasmine = new Jasmine();
+jasmine.loadConfig({
+  'spec_dir': 'spec',
+  'spec_files': [
+    "BitbucketServer/**/*[sS]pec.js"
+  ],
+  "random": false,
+  "stopSpecOnExpectationFailure": true
+});
+jasmine.execute();

--- a/spec/Machine/suppress-duplicate.spec.js
+++ b/spec/Machine/suppress-duplicate.spec.js
@@ -24,8 +24,8 @@ describe('Machine', () => {
     const includePathOriginal = `${backslashToSlash(__dirname)}/../fixtures/lib/a.builder`;
     const includePathDuplicated = `${backslashToSlash(__dirname)}/../fixtures/lib/a.builder_copy`;
     const text = `Warning: duplicated includes detected! The same exact file content is included from
-    main:1 (${includePathOriginal})
-    main:2 (${includePathDuplicated})`;
+--- main:1 (${includePathOriginal})
+--- main:2 (${includePathDuplicated})`;
     const duplicateWarning = `\x1b[33m${text}\u001b[39m\n`;
     try {
       // Capture STDERR messages
@@ -44,8 +44,8 @@ describe('Machine', () => {
 
       machine.suppressDupWarning = false;
       const res = eol.lf(machine.execute(
-        `@include once "${backslashToSlash(__dirname)}/../fixtures/lib/a.builder"
-@include once "${backslashToSlash(__dirname)}/../fixtures/lib/a.builder_copy"`
+        `@include "${backslashToSlash(__dirname)}/../fixtures/lib/a.builder"
+@include "${backslashToSlash(__dirname)}/../fixtures/lib/a.builder_copy"`
       ));
       expect(res).toEqual(`a.builder\na.builder\n`);
     } catch (e) {
@@ -64,8 +64,8 @@ describe('Machine', () => {
       });
 
       const res = eol.lf(machine.execute(
-        `@include once "${backslashToSlash(__dirname)}/../fixtures/lib/a.builder"
-@include once "${backslashToSlash(__dirname)}/../fixtures/lib/a.builder_copy"`
+        `@include "${backslashToSlash(__dirname)}/../fixtures/lib/a.builder"
+@include "${backslashToSlash(__dirname)}/../fixtures/lib/a.builder_copy"`
       ));
       expect(res).toEqual(`a.builder\na.builder\n`);
     } catch (e) {

--- a/spec/Machine/use-directives.spec.js
+++ b/spec/Machine/use-directives.spec.js
@@ -64,7 +64,7 @@ describe('Machine', () => {
       Int0: 990,
       Int1: 991,
     };
-  
+
     const directivesSource = "@{Int0} @{Int1}";
     const expectedOutput = `990 991`;
 
@@ -96,7 +96,7 @@ describe('Machine', () => {
       Int1: 551,
       Int2: 552,
     };
-  
+
     const directivesSource = "@{Int0} @{Int1} @{Int2}";
     const expectedOutput = `550 551 552`;
 
@@ -137,7 +137,7 @@ describe('Machine', () => {
       Int1: 551,
       Int2: 552,
     };
-  
+
     const directivesSource = "@{Int0} @{Int1} @{Int2}";
     const expectedOutput = `550 551 552`;
 

--- a/spec/support/jasmine.json
+++ b/spec/support/jasmine.json
@@ -1,9 +1,11 @@
 {
   "spec_dir": "spec",
   "spec_files": [
-    "**/*[sS]pec.js"
+    "**/*[sS]pec.js",
+    "!BitbucketServer/**/*[sS]pec.js"
   ],
   "helpers": [
     "helpers/**/*.js"
-  ]
+  ],
+  "random": false
 }

--- a/src/FileCache.js
+++ b/src/FileCache.js
@@ -30,9 +30,10 @@ const minimatch = require('minimatch');
 const XXHash = require('xxhashjs');
 const HttpReader = require('./Readers/HttpReader');
 const GithubReader = require('./Readers/GithubReader');
+const BitbucketServerReader = require('./Readers/BitbucketServerReader');
 
 const DEFAULT_EXCLUDE_FILE_NAME = 'builder-cache.exclude';
-const CACHED_READERS = [GithubReader, HttpReader];
+const CACHED_READERS = [GithubReader, BitbucketServerReader, HttpReader];
 const CACHE_LIFETIME = 1; // in days
 const HASH_SEED = 0xE1EC791C;
 const MAX_FILENAME_LENGTH = 250;
@@ -49,7 +50,7 @@ class FileCache {
   }
 
   /**
-   * Transform url or github link to path and filename
+   * Transform url or github/bitbucket link to path and filename
    * It is important, that path and filename are unique,
    * because collision can break the build
    * @param {string} link link to the file
@@ -57,6 +58,7 @@ class FileCache {
    * @private
    */
   _getCachedPath(link) {
+    link = link.replace(/^bitbucket-server\:/, 'bitbucket-server#'); // replace ':' for '#' in bitbucket-server protocol
     link = link.replace(/^github\:/, 'github#'); // replace ':' for '#' in github protocol
     link = link.replace(/\:\/\//, '#'); // replace '://' for '#' in url
     link = link.replace(/\//g, '-'); // replace '/' for '-'

--- a/src/FileCache.js
+++ b/src/FileCache.js
@@ -140,9 +140,12 @@ class FileCache {
    * @return {content: string, includePathParsed} content and parsed path
    * @private
    */
-  read(reader, includePath, dependencies) {
+  read(reader, includePath, dependencies, context) {
+    // Do this first as our includePath and reader may change on us if we have a cache hit
+    let includePathParsed = reader.parsePath(includePath);
+
     let needCache = false;
-    if (!dependencies && this._toBeCached(includePath) && this._isCachedReader(reader)) {
+    if ((!dependencies || dependencies.get(includePath) === undefined) && this._toBeCached(includePath) && this._isCachedReader(reader)) {
       let result;
       if ((result = this._findFile(includePath)) && !this._isCacheFileOutdate(result)) {
         // change reader to local reader
@@ -154,8 +157,7 @@ class FileCache {
       }
     }
 
-    const includePathParsed = reader.parsePath(includePath);
-    let content = reader.read(includePath, { dependencies: dependencies });
+    let content = reader.read(includePath, { dependencies: dependencies, context: context });
 
     // if content doesn't have line separator at the end, then add it
     if (content.length > 0 && content[content.length - 1] != '\n') {

--- a/src/FileCache.js
+++ b/src/FileCache.js
@@ -139,6 +139,9 @@ class FileCache {
    * @private
    */
   read(reader, includePath, dependencies, context) {
+    // Do this first as our includePath and reader may change on us if we have a cache hit
+    let includePathParsed = reader.parsePath(includePath);
+
     let needCache = false;
     if ((!dependencies || dependencies.get(includePath) === undefined) && this._toBeCached(includePath) && this._isCachedReader(reader)) {
       let result;
@@ -152,7 +155,6 @@ class FileCache {
       }
     }
 
-    const includePathParsed = reader.parsePath(includePath);
     let content = reader.read(includePath, { dependencies: dependencies, context: context });
 
     // if content doesn't have line separator at the end, then add it

--- a/src/FileCache.js
+++ b/src/FileCache.js
@@ -138,9 +138,9 @@ class FileCache {
    * @return {content: string, includePathParsed} content and parsed path
    * @private
    */
-  read(reader, includePath, dependencies) {
+  read(reader, includePath, dependencies, context) {
     let needCache = false;
-    if (!dependencies && this._toBeCached(includePath) && this._isCachedReader(reader)) {
+    if ((!dependencies || dependencies.get(includePath) === undefined) && this._toBeCached(includePath) && this._isCachedReader(reader)) {
       let result;
       if ((result = this._findFile(includePath)) && !this._isCacheFileOutdate(result)) {
         // change reader to local reader
@@ -153,7 +153,7 @@ class FileCache {
     }
 
     const includePathParsed = reader.parsePath(includePath);
-    let content = reader.read(includePath, { dependencies: dependencies });
+    let content = reader.read(includePath, { dependencies: dependencies, context: context });
 
     // if content doesn't have line separator at the end, then add it
     if (content.length > 0 && content[content.length - 1] != '\n') {

--- a/src/Machine.js
+++ b/src/Machine.js
@@ -174,7 +174,7 @@ class Machine {
   _formatPath(filepath, filename) {
     return path.normalize(path.join(filepath, filename));
   }
-  
+
   /**
    * Execute AST
    * @param {[]} ast
@@ -285,19 +285,14 @@ class Machine {
   }
 
   /**
-   * Concatenate github URL prefix and local relative include
+   * Concatenate github/bitbucket URL prefix and local relative include
    * @param {string[]} prefix
    * @param {string[]} includePath
    * @private
    */
   _formatURL(prefix, includePath) {
-
-    const URL = url.parse(prefix);
-    if (!URL.protocol) {
-      return undefined;
-    }
-
-    const res = prefix.match(/(github:)(.*)/);
+    const res = prefix.match(/^(github:)(.*)/) ||
+                prefix.match(/^(bitbucket-server:)(.*)/);
     if (res === null) {
       return undefined;
     }
@@ -307,7 +302,7 @@ class Machine {
   }
 
   /**
-   * Replace local includes to github URLs if requested
+   * Replace local includes to github/bitbucket URLs if requested
    * @param {string} includePath
    * @param {{}} context
    * @private
@@ -333,9 +328,12 @@ class Machine {
       return includePath;
     }
 
-    // check if file is included from github source
+    // check if file is included from github or Bitbucket server
     const remotePath = this._formatURL(context.__PATH__, includePath);
-    if (remotePath && this._getReader(remotePath) === this.readers.github) {
+    const isGithubSource = remotePath && (this._getReader(remotePath) === this.readers.github);
+    const isBitbucketSrvSource = remotePath && (this._getReader(remotePath) === this.readers.bitbucketSrv);
+
+    if (isGithubSource || isBitbucketSrvSource) {
       return context.__REF__ ? `${remotePath}@${context.__REF__}` : remotePath;
     }
 
@@ -365,7 +363,7 @@ class Machine {
       return;
     }
 
-    // checkout local includes in the github sources from github
+    // checkout local includes in the github/bitbucket sources from github/bitbucket
     includePath = this._remoteRelativeIncludes(includePath, context);
 
     const reader = this._getReader(includePath);

--- a/src/Machine.js
+++ b/src/Machine.js
@@ -325,13 +325,16 @@ class Machine {
 
     // Check to see if file is a github absolute remote path, in which case we should return that path back directly
     if(this._getReader(includePath) === this.readers.github){
-      return includePath
+      if(includePath.indexOf(context.__REPO_PREFIX__) > -1)
+        return context.__REPO_REF__ ? `${path.join(includePath)}@${context.__REPO_REF__}` : path.join(includePath); // Potentially someone using __PATH__
+      else
+        return includePath  // Absolute github include
     }
 
     // check if file is included from github source - if so, modify the path and return it relative to the repo root
     const remotePath = this._formatURL(context.__PATH__, includePath);
     if (remotePath && this._getReader(remotePath) === this.readers.github) {
-      return context.__REF__ ? `${remotePath}@${context.__REF__}` : remotePath;
+      return context.__REPO_REF__ ? `${remotePath}@${context.__REPO_REF__}` : remotePath;
     }
 
     // Both FileReader and GithubReader now search in this order:

--- a/src/Machine.js
+++ b/src/Machine.js
@@ -174,7 +174,7 @@ class Machine {
   _formatPath(filepath, filename) {
     return path.normalize(path.join(filepath, filename));
   }
-  
+
   /**
    * Execute AST
    * @param {[]} ast
@@ -323,21 +323,33 @@ class Machine {
      * function and implemented for every reader type independently.
      */
 
-    // check if the file is included locally
-    if (this._getReader(includePath) !== this.readers.file) {
-      return includePath;
+    // Check to see if file is a github absolute remote path, in which case we should return that path back directly
+    if(this._getReader(includePath) === this.readers.github){
+      return includePath
     }
 
-    // check that path is not absolute
-    if (path.isAbsolute(includePath)) {
-      return includePath;
-    }
-
-    // check if file is included from github source
+    // check if file is included from github source - if so, modify the path and return it relative to the repo root
     const remotePath = this._formatURL(context.__PATH__, includePath);
     if (remotePath && this._getReader(remotePath) === this.readers.github) {
       return context.__REF__ ? `${remotePath}@${context.__REF__}` : remotePath;
     }
+
+    // Both FileReader and GithubReader now search in this order:
+    // - Relative to process.cwd() / repo root
+    // - Relative to process.cwd() / repo root + current context.__PATH__
+    // - Absolute path of context.__PATH__ + includePath
+    // - Absolute path of includePath
+
+    // // check that path is not absolute
+    // if (path.isAbsolute(includePath)) {
+    //   return includePath;
+    // }
+
+    // // check if the file is included locally
+    // if (this._getReader(includePath) === this.readers.file) {
+    //   return includePath
+    //   // return context.__PATH__ + "/" + includePath;
+    // }
 
     return includePath;
   }
@@ -359,24 +371,32 @@ class Machine {
       context,
     ).trim();
 
-    // if once flag is set, then check if source has already been included
-    if (once && this._includedSources.has(includePath)) {
-      this.logger.debug(`Skipping source "${includePath}": has already been included`);
-      return;
-    }
-
     // checkout local includes in the github sources from github
     includePath = this._remoteRelativeIncludes(includePath, context);
 
+    // if once flag is set, then check if source has already been included (and avoid the read below if avoidable)
+    if (once && this._includedSources.has(includePath)) {
+      this.logger.debug(`Skipping source "${includePath}" - contents have already been included previously`);
+      return;
+    }
+
     const reader = this._getReader(includePath);
-    this.logger.info(`Including source "${includePath}"`);
+    this.logger.info(`Including source "${includePath}" with context.__PATH__ = "${context.__PATH__}"`);
 
     // read
-    const res = this.fileCache.read(reader, includePath, this.dependencies);
+    const res = this.fileCache.read(reader, includePath, this.dependencies, context)
+
+    const md5sum = md5(res.content);
+
+    // if once flag is set, then check if source has already been included
+    if (once && this._includedSourcesHashes.has(md5sum)) {
+      this._includedSources.add(includePath)  // Prevent fetches in the future for the same path
+      this.logger.debug(`Skipping source "${includePath}" - contents have already been included previously`);
+      return;
+    }
 
     // Check if source with same hash value has already been included
     if (!this.suppressDupWarning) {
-      const md5sum = md5(res.content);
       if (this._includedSourcesHashes.has(md5sum)) {
         const path = this._includedSourcesHashes.get(md5sum).path;
         const file = this._includedSourcesHashes.get(md5sum).file;
@@ -385,8 +405,8 @@ class Machine {
         const dupFile = context.__FILE__;
         const dupLine = context.__LINE__;
         const message = `Warning: duplicated includes detected! The same exact file content is included from
-    ${file}:${line} (${path})
-    ${dupFile}:${dupLine} (${dupPath})`;
+--- ${file}:${line} (${path})
+--- ${dupFile}:${dupLine} (${dupPath})`;
 
         console.error("\x1b[33m" + message + '\u001b[39m');
       }

--- a/src/Machine.js
+++ b/src/Machine.js
@@ -325,10 +325,15 @@ class Machine {
 
     // Check to see if file is a github absolute remote path, in which case we should return that path back directly
     if(this._getReader(includePath) === this.readers.github){
-      if(includePath.indexOf(context.__REPO_PREFIX__) > -1)
-        return context.__REPO_REF__ ? `${path.join(includePath)}@${context.__REPO_REF__}` : path.join(includePath); // Potentially someone using __PATH__
-      else
+      if(includePath.indexOf(context.__REPO_PREFIX__) > -1){
+        var rv = context.__REPO_REF__ ? `${path.join(includePath)}@${context.__REPO_REF__}` : path.join(includePath); // Potentially someone using __PATH__
+        if(process.platform === "win32"){
+          rv = rv.replace(/\\/g, '/');
+        }
+        return rv
+      } else{
         return includePath  // Absolute github include
+      }
     }
 
     // check if file is included from github source - if so, modify the path and return it relative to the repo root

--- a/src/Readers/BitbucketServerReader.js
+++ b/src/Readers/BitbucketServerReader.js
@@ -1,0 +1,377 @@
+// MIT License
+//
+// Copyright 2019 Electric Imp
+//
+// SPDX-License-Identifier: MIT
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO
+// EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES
+// OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+// ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+// OTHER DEALINGS IN THE SOFTWARE.
+
+'use strict';
+
+const request = require('request');
+const path = require('path');
+const upath = require('upath');
+const childProcess = require('child_process');
+const AbstractReader = require('./AbstractReader');
+
+// Common API path
+const API_PATH = "rest/api/1.0/";
+// Child process timeout
+const TIMEOUT = 30000;
+// Child process error return code
+const STATUS_FETCH_FAILED = 2;
+// Marker presence on the command line tells that we're in the worker thread
+const WORKER_MARKER = '__bitbucket_srv_reader_worker__';
+
+class BitbucketServerReader extends AbstractReader {
+
+  constructor() {
+    super();
+    this.timeout = TIMEOUT;
+  }
+
+  /**
+   * Checks if the requested source can be read by this reader
+   * @param {string} source
+   * @return {boolean}
+   */
+  supports(source) {
+    return BitbucketServerReader.parseUrl(source) !== false;
+  }
+
+  /**
+   * Reads file from Bitbucket server
+   * @param {string} source - source URI
+   * @param {object} options - options such as dependencies map
+   * @return {string}
+   */
+  read(source, options) {
+    this.logger.debug(`Reading Bitbucket-server source "${source}"...`);
+
+    if (!this.serverAddr) {
+      throw 'Bitbucket server address is not specified';
+    }
+
+    var commitID = null;
+    var needCommitID = false;
+
+    // Process dependencies
+    if (options && options.dependencies) {
+      if (options.dependencies.has(source)) {
+        commitID = options.dependencies.get(source);
+      } else {
+        needCommitID = true;
+      }
+    }
+
+    // Spawn child process
+    const child = childProcess.spawnSync(
+      /* node */ process.argv[0],
+      [/* self */ __filename,
+        WORKER_MARKER,
+        this.serverAddr,
+        source,
+        this.username,
+        this.token,
+        commitID,
+        needCommitID
+      ],
+      { timeout: this.timeout }
+    );
+
+    if (child.status === STATUS_FETCH_FAILED) {
+      // Predefined exit code errors
+      throw new AbstractReader.Errors.SourceReadingError(child.stderr.toString());
+    } else if (child.status) {
+      // Misc exit code errors
+      throw new AbstractReader.Errors.SourceReadingError(
+        `Unknown error: ${child.stderr.toString()} (exit code ${child.status})`
+      );
+    } else {
+      // Errors that do not set erroneous exit code
+      if (child.error) {
+        if (child.error.errno === 'ETIMEDOUT') {
+          // Timeout
+          throw new AbstractReader.Errors.SourceReadingError(
+            `Failed to fetch url "${source}": timed out after ${this.timeout / 1000}s`
+          );
+        } else {
+          // Others
+          throw new AbstractReader.Errors.SourceReadingError(
+            `Failed to fetch url "${source}": ${child.error.errno}`
+          );
+        }
+      } else if (child.status === null) {
+        // No status code is set, no error is set
+        throw new AbstractReader.Errors.SourceReadingError(
+          `Unknown error: "${source}"`
+        );
+      } else {
+        // Success
+        const ret = JSON.parse(child.output[1].toString());
+
+        // Update dependencies map if needed
+        if (needCommitID) {
+          options.dependencies.set(source, ret.commitID);
+        }
+
+        return ret.data;
+      }
+    }
+  }
+
+  /**
+   * Parses source URI into __FILE__/__PATH__/__REF__
+   * @param {string} source - source URI
+   * @return {{__FILE__, __PATH__, __REF__}}
+   */
+  parsePath(source) {
+    const parsed = BitbucketServerReader.parseUrl(source);
+    return {
+      __FILE__: path.basename(parsed.path),
+      __PATH__: `bitbucket-server:${parsed.project}/${parsed.repo}/${path.dirname(parsed.path)}`,
+      __REF__: parsed.ref
+    };
+  }
+
+  /**
+   * Fetches the source and outputs it to STDOUT
+   * @param {string} serverAddr - address of the Bitbucket server to fetch the file from
+   * @param {string} source - source URI
+   * @param {string} username - username (if required)
+   * @param {string} password - password or token (if required)
+   * @param {string} commitID - commit ID (SHA) if any specific commit (version of the file) should be used
+   * @param {string} needCommitID - "true" if commit ID (SHA) is needed along with the file data
+   * @return {{data, commitID}}
+   */
+  static fetch(serverAddr, source, username, password, commitID, needCommitID) {
+    var auth = null;
+
+    if (username !== '' && password !== '') {
+      auth = {
+        "type": "basic",
+        "username": username,
+        "password": password
+      };
+    }
+
+    if (serverAddr.slice(-1) !== "/") {
+      serverAddr += "/";
+    }
+
+    const sourceParsed = this.parseUrl(source);
+    var ref = null;
+
+    // commitID is always a string because it was passed as an arg of a process (childProcess.spawnSync)
+    if (commitID !== "null") {
+      ref = commitID;
+    } else if (sourceParsed.ref !== undefined) {
+      ref = sourceParsed.ref;
+    }
+
+    const promises = [BitbucketServerReader.downloadFile(serverAddr, auth, sourceParsed, ref)];
+
+    // needCommitID is always a string because it was passed as an arg of a process (childProcess.spawnSync)
+    if (needCommitID === "true") {
+      promises.push(BitbucketServerReader.getCommitID(serverAddr, auth, sourceParsed, ref));
+    }
+
+    Promise.all(promises).then(function(results) {
+      const ret = {
+        data: results[0],
+        commitID: results[1]
+      };
+
+      process.stdout.write(JSON.stringify(ret));
+    });
+  }
+
+  /**
+   * Makes an HTTP request to download the source file
+   * @param {string} serverAddr - address of the Bitbucket server to fetch the file from
+   * @param {object} auth - authentication info
+   * @param {object} sourceParsed - parsed source URI
+   * @param {string} ref - git branch name / tag / commit ID (SHA)
+   * @return {Promise}
+   */
+  static downloadFile(serverAddr, auth, sourceParsed, ref) {
+    sourceParsed.path = upath.normalize(sourceParsed.path);
+
+    var url = serverAddr + API_PATH + `projects/${sourceParsed.project}/repos/${sourceParsed.repo}/raw/${sourceParsed.path}`;
+
+    if (ref !== null) {
+      url += "?at=" + ref;
+    }
+
+    const params = {
+      uri: url,
+      auth: auth,
+      json: true,
+      // NOTE: This parameter is not required in the general case and, moreover, it can affect security
+      // But without it, Builder can't access Bitbucket servers with self-signed SSL certificates
+      // This can be replaced with a more safe and right solution later
+      rejectUnauthorized: false
+    };
+
+    return new Promise(function(resolve, reject) {
+      request.get(params, (error, resp, body) => {
+        BitbucketServerReader.checkResponse(url, error, resp);
+        resolve(body);
+      });
+    });
+  }
+
+  /**
+   * Makes an HTTP request to get the latest commit ID (SHA) correspondig to the optional ref specified in the source URI
+   * @param {string} serverAddr - address of the Bitbucket server to fetch the file from
+   * @param {object} auth - authentication info
+   * @param {object} sourceParsed - parsed source URI
+   * @param {string} ref - git branch name / tag / commit ID (SHA)
+   * @return {Promise}
+   */
+  static getCommitID(serverAddr, auth, sourceParsed, ref) {
+    var url = serverAddr + API_PATH + `projects/${sourceParsed.project}/repos/${sourceParsed.repo}/commits`;
+    // We want to get only the latest commit, so we are setting limit=1
+    url += "?limit=1";
+
+    if (ref !== null) {
+      // Set the ref to retrieve commits before (inclusively)
+      url += "&until=" + ref;
+    }
+
+    const params = {
+      uri: url,
+      auth: auth,
+      json: true,
+      // NOTE: This parameter is not required in the general case and, moreover, it can affect security
+      // But without it, Builder can't access Bitbucket servers with self-signed SSL certificates
+      // This can be replaced with a more safe and right solution later
+      rejectUnauthorized: false
+    };
+
+    return new Promise(function(resolve, reject) {
+      request.get(params, (error, resp, body) => {
+        BitbucketServerReader.checkResponse(url, error, resp);
+
+        const commitID = body.values[0].id;
+        resolve(commitID);
+      });
+    });
+  }
+
+  /**
+   * Checks the response of an HTTP request. Terminates the process in case of an error
+   * @param {string} url - request URL
+   * @param {string} error - error message
+   * @param {string} resp - response of the request
+   * @return {{__FILE__, __PATH__, __REF__}}
+   */
+  static checkResponse(url, error, resp) {
+    try {
+      if (error) {
+        process.stderr.write(`Failed to fetch url "${url}": ${error}\n`);
+        process.exit(STATUS_FETCH_FAILED);
+      } else if (resp.statusCode < 200 || resp.statusCode >= 300) {
+        process.stderr.write(`Failed to fetch url "${url}": HTTP/${resp.statusCode}\n`);
+
+        // In many cases Bitbucket server includes error message(s)
+        process.stderr.write(`Response from the server: ${JSON.stringify(resp.body)}\n`);
+
+        process.exit(STATUS_FETCH_FAILED);
+      }
+    } catch (err) {
+      process.stderr.write(`Failed to fetch url "${url}": ${err}\n`);
+      process.exit(STATUS_FETCH_FAILED);
+    }
+  }
+
+  /**
+   * Parse Bitbucket server reference into parts
+   * @param source
+   * @return {false|{user, repo, path, ref}}
+   */
+  static parseUrl(source) {
+    const m = source.match(
+      /^(bitbucket-server:)(~?[a-z0-9\-\._]+)\/([a-z0-9\-\._]+)\/(.*?)(?:@([^@]*))?$/i
+    );
+
+    if (m) {
+      const res = {
+        'project': m[2],
+        'repo': m[3],
+        'path': m[4],
+      };
+
+      if (undefined !== m[5]) {
+        res.ref = m[5];
+      }
+
+      return res;
+    }
+
+    return false;
+  }
+
+  get timeout() {
+    return this._timeout;
+  }
+
+  set timeout(value) {
+    this._timeout = value;
+  }
+
+  get serverAddr() {
+    return this._serverAddr || '';
+  }
+
+  set serverAddr(value) {
+    this._serverAddr = value;
+  }
+
+  get username() {
+    return this._username || '';
+  }
+
+  set username(value) {
+    this._username = value;
+  }
+
+  get token() {
+    return this._token || '';
+  }
+
+  set token(value) {
+    this._token = value;
+  }
+
+  get password() {
+    return this._token || '';
+  }
+
+  set password(value) {
+    this._token = value;
+  }
+}
+
+if (process.argv.indexOf(WORKER_MARKER) !== -1) {
+  // Launch worker
+  BitbucketServerReader.fetch(process.argv[3], process.argv[4], process.argv[5], process.argv[6], process.argv[7], process.argv[8]);
+} else {
+  module.exports = BitbucketServerReader;
+}

--- a/src/Readers/BitbucketServerReader.js
+++ b/src/Readers/BitbucketServerReader.js
@@ -137,16 +137,17 @@ class BitbucketServerReader extends AbstractReader {
   }
 
   /**
-   * Parses source URI into __FILE__/__PATH__/__REF__
+   * Parses source URI into __FILE__/__PATH__/__REPO_REF__/__REPO_PREFIX__
    * @param {string} source - source URI
-   * @return {{__FILE__, __PATH__, __REF__}}
+   * @return {{__FILE__, __PATH__, __REPO_REF__, __REPO_PREFIX__}}
    */
   parsePath(source) {
     const parsed = BitbucketServerReader.parseUrl(source);
     return {
       __FILE__: path.basename(parsed.path),
       __PATH__: `bitbucket-server:${parsed.project}/${parsed.repo}/${path.dirname(parsed.path)}`,
-      __REF__: parsed.ref
+      __REPO_REF__: parsed.ref,
+      __REPO_PREFIX__: `bitbucket-server:${parsed.project}/${parsed.repo}`
     };
   }
 
@@ -280,7 +281,6 @@ class BitbucketServerReader extends AbstractReader {
    * @param {string} url - request URL
    * @param {string} error - error message
    * @param {string} resp - response of the request
-   * @return {{__FILE__, __PATH__, __REF__}}
    */
   static checkResponse(url, error, resp) {
     try {

--- a/src/Readers/FileReader.js
+++ b/src/Readers/FileReader.js
@@ -36,7 +36,7 @@ class FileReader extends AbstractReader {
   constructor() {
     super();
     this.searchDirs = [
-      path.resolve('.')
+      path.resolve('.'),
     ];
   }
 
@@ -50,9 +50,16 @@ class FileReader extends AbstractReader {
    * @param {string} filePath
    * @return {string}
    */
-  read(filePath) {
+  read(filePath, options) {
+
+    var searchDirs = this.searchDirs.concat(
+      path.resolve(".") + options.context.__PATH__,
+      options.context.__PATH__,
+      '' /* to try as absolute path */
+    )
+
     // iterate through the search dirs
-    for (const dir of this.searchDirs.concat('' /* to try as absolute path */)) {
+    for (const dir of searchDirs) {
       const sourcePath = path.join(dir, filePath);
 
       if (fs.existsSync(sourcePath)) {

--- a/src/Readers/GithubReader.js
+++ b/src/Readers/GithubReader.js
@@ -142,7 +142,8 @@ class GithubReader extends AbstractReader {
     return {
       __FILE__: path.basename(parsed.path),
       __PATH__: `github:${parsed.owner}/${parsed.repo}/${path.dirname(parsed.path)}`,
-      __REF__: parsed.ref
+      __REPO_REF__: parsed.ref,
+      __REPO_PREFIX__: `github:${parsed.owner}/${parsed.repo}`
     };
   }
 
@@ -177,23 +178,25 @@ class GithubReader extends AbstractReader {
       agent = HttpsProxyAgent(process.env.https_proxy);
     }
 
-    const octokit = new Octokit({
+    const octokitConfig = {
       userAgent: packageJson.name + '/' + packageJson.version,
       baseUrl: 'https://api.github.com',
       request: {
         agent: agent,
         timeout: 5000
-      },
-    });
+      }
+    };
 
     // authorization
     if (username != '' && password !== '') {
-      octokit.authenticate({
+      octokitConfig.auth = {
         type: 'basic',
         username,
         password
-      });
+      };
     }
+
+    const octokit = new Octokit(octokitConfig);
 
     if (gitBlobID !== 'undefined') {
       const args = {

--- a/src/Readers/GithubReader.js
+++ b/src/Readers/GithubReader.js
@@ -184,16 +184,12 @@ class GithubReader extends AbstractReader {
         agent: agent,
         timeout: 5000
       },
-    });
-
-    // authorization
-    if (username != '' && password !== '') {
-      octokit.authenticate({
+      auth: {
         type: 'basic',
-        username,
-        password
-      });
-    }
+        "username": username,
+        "password": password
+      }
+    });
 
     if (gitBlobID !== 'undefined') {
       const args = {

--- a/src/Readers/GithubReader.js
+++ b/src/Readers/GithubReader.js
@@ -142,7 +142,8 @@ class GithubReader extends AbstractReader {
     return {
       __FILE__: path.basename(parsed.path),
       __PATH__: `github:${parsed.owner}/${parsed.repo}/${path.dirname(parsed.path)}`,
-      __REF__: parsed.ref
+      __REPO_REF__: parsed.ref,
+      __REPO_PREFIX__: `github:${parsed.owner}/${parsed.repo}`
     };
   }
 

--- a/src/cli.js
+++ b/src/cli.js
@@ -62,6 +62,7 @@ function usageInfo() {
 
 usage:\n\t\u001b[34m${Object.getOwnPropertyNames((packageJson.bin))[0]} [-l] [-D<variable> <value>]
 \t\t[--github-user <username> --github-token <token>]
+\t\t[--bitbucket-server-addr <address>] [--bitbucket-server-user <username> --bitbucket-server-token <token>]
 \t\t[--lib <path_to_file>] [--use-remote-relative-includes] [--suppress-duplicate-includes-warning]
 \t\t[--cache] [--clear-cache] [--cache-exclude-list <path_to_file>]
 \t\t[--save-dependencies [<path_to_file>]] [--use-dependencies [<path_to_file>]]
@@ -72,6 +73,9 @@ where:
 \t\u001b[34m-D<varname> <value>\u001b[39m - defines a variable
 \t\u001b[34m--github-user <username>\u001b[39m - a GitHub username
 \t\u001b[34m--github-token <token>\u001b[39m - a GitHub personal access token or password
+\t\u001b[34m--bitbucket-server-addr <address>\u001b[39m - a Bitbucket Server address
+\t\u001b[34m--bitbucket-server-user <username>\u001b[39m - a Bitbucket Server username
+\t\u001b[34m--bitbucket-server-token <token>\u001b[39m - a Bitbucket Server personal access token or password
 \t\u001b[34m--lib <path_to_file>\u001b[39m - include the specified JavaScript file(s) as a library
 \t\u001b[34m--use-remote-relative-includes\u001b[39m - interpret every local include as relative to the location of the source file where it is mentioned
 \t\u001b[34m--suppress-duplicate-includes-warning\u001b[39m - do not show a warning if a source file with the same content was included multiple times
@@ -115,6 +119,7 @@ function readArgs() {
     lineControl: false,
     input: null,
     gh: {user: null, token: null},
+    bbSrv: {addr: null, user: null, token: null},
     clean : false,
     excludeFile : '',
     cacheFolder: '',
@@ -149,6 +154,21 @@ function readArgs() {
         throw Error('Expected argument value after ' + argument);
       }
       res.gh.token = args.shift();
+    } else if (argument === '--bitbucket-server-addr') {
+      if (!args.length) {
+        throw Error('Expected argument value after ' + argument);
+      }
+      res.bbSrv.addr = args.shift();
+    } else if (argument === '--bitbucket-server-user') {
+      if (!args.length) {
+        throw Error('Expected argument value after ' + argument);
+      }
+      res.bbSrv.user = args.shift();
+    } else if (argument === '--bitbucket-server-token') {
+      if (!args.length) {
+        throw Error('Expected argument value after ' + argument);
+      }
+      res.bbSrv.token = args.shift();
     } else if (argument === '--lib' || argument === '--libs') {
       if (!args.length) {
         throw Error('Expected argument value after ' + argument);
@@ -210,6 +230,10 @@ try {
   // set GH credentials
   builder.machine.readers.github.username = args.gh.user;
   builder.machine.readers.github.token = args.gh.token;
+  // set BB-Server addr and credentials
+  builder.machine.readers.bitbucketSrv.serverAddr = args.bbSrv.addr;
+  builder.machine.readers.bitbucketSrv.username = args.bbSrv.user;
+  builder.machine.readers.bitbucketSrv.token = args.bbSrv.token;
   //set cache settings
   builder.machine.excludeList = args.excludeFile;
   // set remote relative includes
@@ -228,7 +252,7 @@ try {
   process.stdout.write(res);
 
 } catch (e) {
-  console.error('\u001b[31m' + ( e.message || e) + '\u001b[39m');
+  console.error('\u001b[31m' + (e.message || e) + '\u001b[39m');
   process.exit(1);
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -33,6 +33,7 @@ const Expression = require('./Expression');
 const FileReader = require('./Readers/FileReader');
 const HttpReader = require('./Readers/HttpReader');
 const GithubReader = require('./Readers/GithubReader');
+const BitbucketServerReader = require('./Readers/BitbucketServerReader');
 
 /**
  * Main Builder class
@@ -109,11 +110,13 @@ class Builder {
     const fileReader = new FileReader();
     const httpReader = new HttpReader();
     const githubReader = new GithubReader();
+    const bitbucketServerReader = new BitbucketServerReader();
 
     const parser = new AstParser();
     const machine = new Machine();
     const expression = new Expression(machine);
 
+    machine.readers.bitbucketSrv = bitbucketServerReader;
     machine.readers.github = githubReader;
     machine.readers.http = httpReader;
     machine.readers.file = fileReader;


### PR DESCRIPTION
Solution for: https://github.com/electricimp/Builder/issues/43

- A new reader to support includes from Bitbucket Server
- Support "save-dependencies/use-dependencies" options for the new reader
- Support "remote-relative-includes" option for the new reader
- Tests for the new reader
- Update README.md
- Merge changes from https://github.com/deldrid1/Builder/tree/hotfix/remote-relative-includes
- Now tests pass (they have been fixed after the changes from hotfix/remote-relative-includes)

**Note1**: Currently, only one server can be specified/used to fetch all Bitbucket Server includes. Later we can add support for multiple servers if someone needs it.

**Note2**: `rejectUnauthorized: false` parameter is used for HTTP requests to allow Builder work with  Bitbucket servers with self-signed SSL certificates. This parameter is not required in the general case and, moreover, it can affect security. It can be added as a CLI-option later if required.
Also, we can think about an option allowing to set custom CAs instead of `rejectUnauthorized: false` parameter. This is a more right solution but also more complicated.