### PR TITLE
Save-dependencies and use-dependencies options now do not turn off caching for all files; and test added

### DIFF
--- a/src/FileCache.js
+++ b/src/FileCache.js
@@ -140,7 +140,7 @@ class FileCache {
    */
   read(reader, includePath, dependencies) {
     let needCache = false;
-    if (!dependencies && this._toBeCached(includePath) && this._isCachedReader(reader)) {
+    if ((!dependencies || dependencies.get(includePath) === undefined) && this._toBeCached(includePath) && this._isCachedReader(reader)) {
       let result;
       if ((result = this._findFile(includePath)) && !this._isCacheFileOutdate(result)) {
         // change reader to local reader


### PR DESCRIPTION
Test PR for review.