### PR TITLE
Bugfix/emcb 106 bugfixes and improvements

### DIFF
--- a/spec/Machine/cache.spec.js
+++ b/spec/Machine/cache.spec.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2016-2017 Electric Imp
+// Copyright (c) 2016-2020 Electric Imp
 // This file is licensed under the MIT License
 // http://opensource.org/licenses/MIT
 
@@ -157,6 +157,16 @@ describe('FileCache', () => {
       expect(linksSet.has(path)).toEqual(false);
       linksSet.add(path);
     });
+  });
+
+  it('should not change includePathParsed object', () => {
+    let includePath = 'github:electricimp/Builder/spec/fixtures/sample-11/LineBrakeSample.nut';
+    machine.clearCache();
+    machine.useCache = true;
+    const reader = machine._getReader(includePath);
+    const resFirst = machine.fileCache.read(reader, includePath, machine.dependencies);
+    const resSecond = machine.fileCache.read(reader, includePath, machine.dependencies);
+    expect(resSecond.includePathParsed.__PATH__).toBe('github:electricimp/Builder/spec/fixtures/sample-11');
   });
 
 });

--- a/src/FileCache.js
+++ b/src/FileCache.js
@@ -1,6 +1,6 @@
 // MIT License
 //
-// Copyright 2016-2019 Electric Imp
+// Copyright 2016-2020 Electric Imp
 //
 // SPDX-License-Identifier: MIT
 //
@@ -139,6 +139,9 @@ class FileCache {
    * @private
    */
   read(reader, includePath, dependencies) {
+    // Do this first as our includePath and reader may change on us if we have a cache hit
+    const includePathParsed = reader.parsePath(includePath);
+
     let needCache = false;
     if (!dependencies && this._toBeCached(includePath) && this._isCachedReader(reader)) {
       let result;
@@ -152,7 +155,6 @@ class FileCache {
       }
     }
 
-    const includePathParsed = reader.parsePath(includePath);
     let content = reader.read(includePath, { dependencies: dependencies });
 
     // if content doesn't have line separator at the end, then add it

--- a/src/Machine.js
+++ b/src/Machine.js
@@ -1,6 +1,6 @@
 // MIT License
 //
-// Copyright 2016-2019 Electric Imp
+// Copyright 2016-2020 Electric Imp
 //
 // SPDX-License-Identifier: MIT
 //
@@ -174,7 +174,7 @@ class Machine {
   _formatPath(filepath, filename) {
     return path.normalize(path.join(filepath, filename));
   }
-  
+
   /**
    * Execute AST
    * @param {[]} ast
@@ -361,7 +361,7 @@ class Machine {
 
     // if once flag is set, then check if source has already been included
     if (once && this._includedSources.has(includePath)) {
-      this.logger.debug(`Skipping source "${includePath}": has already been included`);
+      this.logger.debug(`Skipping source "${includePath}" - contents have already been included previously`);
       return;
     }
 
@@ -963,4 +963,3 @@ class Machine {
 module.exports = Machine;
 module.exports.INSTRUCTIONS = INSTRUCTIONS;
 module.exports.Errors = Errors;
-


### PR DESCRIPTION
Test PR for review.

Fixed bug in FileCache related to `context` variable. `includePathParsed` variable was getting a wrong value while reading a cached file, now it's fixed.

`includePathParsed` variable was taking a wrong value if the readable file was cached, because the string what had been moved to another place was after [this place](https://github.com/EatonGMBD/Builder/blob/fcb17260f0d5ed056515b9802f3fbe941a9e7260/src/FileCache.js#L152) (in this place `includePath` is changing).
It is related to `context`, because `fileCache.read()` returns `includePathParsed` together with the `context`, and `includePathParsed` then becomes a part of `context`. See [here](https://github.com/EatonGMBD/Builder/blob/fcb17260f0d5ed056515b9802f3fbe941a9e7260/src/Machine.js#L437).
The bug was fixed by moving [the string](https://github.com/EatonGMBD/Builder/blob/80653b878422ce2e6871ba6180e7a323b56ac6b5/src/FileCache.js#L143) to another place.

A test is added into context.spec.js to check this issue. Some log messages changed.