### PR TITLE
feature/emcb-106-include-once-md5 

### DIFF
--- a/spec/Machine/include-once.spec.js
+++ b/spec/Machine/include-once.spec.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2016-2019 Electric Imp
+// Copyright (c) 2016-2020 Electric Imp
 // This file is licensed under the MIT License
 // http://opensource.org/licenses/MIT
 
@@ -33,5 +33,14 @@ describe('Machine', () => {
 @include once "github:electricimp/Builder/spec/fixtures/lib/path.builder@v0.2.0"`
     );
     expect(res).toEqual(`github:electricimp/Builder/spec/fixtures/lib#path.builder@1\n`);
+  });
+
+  it('should handle include-once corectly #3', () => {
+    machine.suppressDupWarning = false;
+    const res = eol.lf(machine.execute(
+      `@include once "${backslashToSlash(__dirname)}/../fixtures/lib/a.builder"
+@include once "${backslashToSlash(__dirname)}/../fixtures/lib/a.builder_copy"`
+    ));
+    expect(res).toEqual(`a.builder\n`);
   });
 });

--- a/spec/Machine/suppress-duplicate.spec.js
+++ b/spec/Machine/suppress-duplicate.spec.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2016-2019 Electric Imp
+// Copyright (c) 2016-2020 Electric Imp
 // This file is licensed under the MIT License
 // http://opensource.org/licenses/MIT
 
@@ -44,8 +44,8 @@ describe('Machine', () => {
 
       machine.suppressDupWarning = false;
       const res = eol.lf(machine.execute(
-        `@include once "${backslashToSlash(__dirname)}/../fixtures/lib/a.builder"
-@include once "${backslashToSlash(__dirname)}/../fixtures/lib/a.builder_copy"`
+        `@include "${backslashToSlash(__dirname)}/../fixtures/lib/a.builder"
+@include "${backslashToSlash(__dirname)}/../fixtures/lib/a.builder_copy"`
       ));
       expect(res).toEqual(`a.builder\na.builder\n`);
     } catch (e) {
@@ -64,8 +64,8 @@ describe('Machine', () => {
       });
 
       const res = eol.lf(machine.execute(
-        `@include once "${backslashToSlash(__dirname)}/../fixtures/lib/a.builder"
-@include once "${backslashToSlash(__dirname)}/../fixtures/lib/a.builder_copy"`
+        `@include "${backslashToSlash(__dirname)}/../fixtures/lib/a.builder"
+@include "${backslashToSlash(__dirname)}/../fixtures/lib/a.builder_copy"`
       ));
       expect(res).toEqual(`a.builder\na.builder\n`);
     } catch (e) {

--- a/src/Machine.js
+++ b/src/Machine.js
@@ -1,6 +1,6 @@
 // MIT License
 //
-// Copyright 2016-2019 Electric Imp
+// Copyright 2016-2020 Electric Imp
 //
 // SPDX-License-Identifier: MIT
 //
@@ -174,7 +174,7 @@ class Machine {
   _formatPath(filepath, filename) {
     return path.normalize(path.join(filepath, filename));
   }
-  
+
   /**
    * Execute AST
    * @param {[]} ast
@@ -361,7 +361,7 @@ class Machine {
 
     // if once flag is set, then check if source has already been included
     if (once && this._includedSources.has(includePath)) {
-      this.logger.debug(`Skipping source "${includePath}": has already been included`);
+      this.logger.debug(`Skipping source "${includePath}": path has already been included`);
       return;
     }
 
@@ -374,31 +374,37 @@ class Machine {
     // read
     const res = this.fileCache.read(reader, includePath, this.dependencies);
 
+    const md5sum = md5(res.content);
+
+    // if once flag is set, then check if source has already been included
+    if (once && this._includedSourcesHashes.has(md5sum)) {
+      this._includedSources.add(includePath)  // Prevent fetches in the future for the same path
+      this.logger.debug(`Skipping source "${includePath}" - contents have already been included previously`);
+      return;
+    }
+
     // Check if source with same hash value has already been included
-    if (!this.suppressDupWarning) {
-      const md5sum = md5(res.content);
-      if (this._includedSourcesHashes.has(md5sum)) {
-        const path = this._includedSourcesHashes.get(md5sum).path;
-        const file = this._includedSourcesHashes.get(md5sum).file;
-        const line = this._includedSourcesHashes.get(md5sum).line;
-        const dupPath = includePath;
-        const dupFile = context.__FILE__;
-        const dupLine = context.__LINE__;
-        const message = `Warning: duplicated includes detected! The same exact file content is included from
+    if (!this.suppressDupWarning && this._includedSourcesHashes.has(md5sum)) {
+      const path = this._includedSourcesHashes.get(md5sum).path;
+      const file = this._includedSourcesHashes.get(md5sum).file;
+      const line = this._includedSourcesHashes.get(md5sum).line;
+      const dupPath = includePath;
+      const dupFile = context.__FILE__;
+      const dupLine = context.__LINE__;
+      const message = `Warning: duplicated includes detected! The same exact file content is included from
     ${file}:${line} (${path})
     ${dupFile}:${dupLine} (${dupPath})`;
 
-        console.error("\x1b[33m" + message + '\u001b[39m');
-      }
-
-      const info = {
-        path: includePath,
-        file: context.__FILE__,
-        line: context.__LINE__,
-      };
-
-      this._includedSourcesHashes.set(md5sum, info);
+      console.error("\x1b[33m" + message + '\u001b[39m');
     }
+
+    const info = {
+      path: includePath,
+      file: context.__FILE__,
+      line: context.__LINE__,
+    };
+
+    this._includedSourcesHashes.set(md5sum, info);
 
     // provide filename for correct error messages
     this.parser.file = res.includePathParsed.__FILE__;
@@ -963,4 +969,3 @@ class Machine {
 module.exports = Machine;
 module.exports.INSTRUCTIONS = INSTRUCTIONS;
 module.exports.Errors = Errors;
-


### PR DESCRIPTION
Test PR for review.
Fixes [#73](https://github.com/electricimp/Builder/issues/73)
The problem with "@include once" feature was that Builder seemed to be unable distinguish inclusion of the same file when arrived upon via different routes or had different name (with exactly same content).
Checking md5 hash sums of included files is the solution of this problem.
"@include once" now detects duplicated includes not by includePath only but using content's md5sum as well. Appropriate test is added, and one test in suppress-duplicate.spec.js is changed due to the new behaviour of "@include once".
For example, if we have files a.nut and a_copy.nut with exactly same content and `suppress-duplicate` flag is not set, then

```
@include once "a.nut"
@include once "a_copy.nut"
```

will result in including content of a.nut only.

Before file is included, it's md5 hash is calculated. If `once` flag is set and hash is already included into `_includedSourcesHashes` , then file is skipped. If above conditions are not met, then `_includedSourcesHashes` adds md5 hash.
`_includedSourcesHashes` is cleared in function `_reset()`.

Note, theoretically this update can break someone's build if he/she intentionally used "include once" for files with different names/pathes but with the identical content (but this seems a rare case anyway).