### PR TITLE
Adding and using context.__ABSOLUTE_PATH__

### DIFF
--- a/spec/Machine/built-in-functions.spec.js
+++ b/spec/Machine/built-in-functions.spec.js
@@ -36,7 +36,8 @@ describe('Machine', () => {
   });
 
   it('should add more paths for local include file searching', () => {
-    const res = machine.execute(`@include once "${backslashToSlash(__dirname)}/../fixtures/sample-10/inc-c.nut"`);
+    const context = {__ABSOLUTE_PATH__: ''};
+    const res = machine.execute(`@include once "${backslashToSlash(__dirname)}/../fixtures/sample-10/inc-c.nut"`, context);
     expect(res.replace('\r\n','\n')).toEqual('// included file d\n');
   });
 });

--- a/spec/Machine/remote-relative-includes.spec.js
+++ b/spec/Machine/remote-relative-includes.spec.js
@@ -37,8 +37,9 @@ describe('Machine', () => {
 
   it('check that include once directive makes distinguish between local and github files', () => {
     machine.remoteRelativeIncludes = true;
+    const context = {__ABSOLUTE_PATH__: ''};
     const res = eol.lf(machine.execute(`@include once "${backslashToSlash(__dirname)}/../fixtures/sample-1/inc-a.nut"
-@include once "${githubPathB}"`));
+@include once "${githubPathB}"`, context));
     expect(res).toEqual('// included file a\n// included file b\n// inc-b.nut:1 # inc-b.nut:1\n');
   });
 });

--- a/src/Machine.js
+++ b/src/Machine.js
@@ -98,7 +98,7 @@ class Machine {
 
     // execute
     context = merge(
-      {__FILE__: this.file, __PATH__: this.path},
+      {__FILE__: this.file, __PATH__: this.path, __ABSOLUTE_PATH__: path.resolve('.')},
       this._builtinFunctions,
       this.globals,
       context
@@ -419,6 +419,11 @@ class Machine {
       context,
       res.includePathParsed
     );
+    if (path.isAbsolute(context.__PATH__)) {
+      context.__ABSOLUTE_PATH__ = context.__PATH__;
+    } else {
+      context.__ABSOLUTE_PATH__ = path.join(context.__ABSOLUTE_PATH__, context.__PATH__);
+    }
 
     // store included source
     this._includedSources.add(includePath);

--- a/src/Readers/FileReader.js
+++ b/src/Readers/FileReader.js
@@ -53,7 +53,7 @@ class FileReader extends AbstractReader {
   read(filePath, options) {
 
     var searchDirs = this.searchDirs.concat (
-      options.context.__PATH__,
+      options.context.__ABSOLUTE_PATH__,
       '' /* to try as absolute path */
     )
 


### PR DESCRIPTION
Before this PR, when Builder tried to get next non-repository file, specified by the `@include` directive, Builder was searching it, concatenating include path to `searchDirs` values with `context.__PATH__` within it.
But `context.__PATH__` wasn't an absolute non-repository path to the file which was currently being processed.
For example, we executed `pleasebuild /temp/a.nut` and `a.nut` contained:
`@include "b/b.nut"`
and `/temp/b/b.nut` contained:
`@include "c/c.nut"`
When `/temp/b/b.nut` was being processed, `context.__PATH__` variable equaled just to `'b'` (as `'b'`is `'b/b.nut'` path without file name). And `/temp/b/c/c.nut` file couldn't be found in this case.
This PR replaces `context.__PATH__` variable with `context.__ABSOLUTE_PATH__` variable which equals to absolute path to currently being processed file.
Appropriate changes was applied to tests: [1](https://github.com/EatonGMBD/Builder/blob/f3b1050c6c2d2e8dcc53cc8854a1ec8bbb6e6f9b/spec/Machine/built-in-functions.spec.js#L38-L42), [2](https://github.com/EatonGMBD/Builder/blob/f3b1050c6c2d2e8dcc53cc8854a1ec8bbb6e6f9b/spec/Machine/remote-relative-includes.spec.js#L38-L44).